### PR TITLE
zipl: Allow optional entries that are left out when files are missing.

### DIFF
--- a/zipl/include/job.h
+++ b/zipl/include/job.h
@@ -13,6 +13,8 @@
 #ifndef JOB_H
 #define JOB_H
 
+#include <stdbool.h>
+
 #include "disk.h"
 #include "zipl.h"
 
@@ -47,6 +49,8 @@ struct job_ipl_data {
 	address_t parm_addr;
 	address_t ramdisk_addr;
 	int is_kdump;
+	bool optional;
+	bool ignore;
 };
 
 struct job_segment_data {

--- a/zipl/include/scan.h
+++ b/zipl/include/scan.h
@@ -16,7 +16,7 @@
 
 
 #define SCAN_SECTION_NUM		9
-#define SCAN_KEYWORD_NUM		22
+#define SCAN_KEYWORD_NUM		23
 #define SCAN_KEYWORD_ONLY_NUM		1
 #define SCAN_AUTOMENU_NAME		"zipl-automatic-menu"
 
@@ -52,6 +52,7 @@ enum scan_keyword_id {
 	scan_keyword_defaultauto = 19,
 	scan_keyword_kdump = 20,
 	scan_keyword_secure = 21,
+	scan_keyword_optional = 22,
 };
 
 enum scan_section_type {

--- a/zipl/man/zipl.conf.5.in
+++ b/zipl/man/zipl.conf.5.in
@@ -447,6 +447,23 @@ This option cannot be used together with either
 .BR 'segment' .
 .PP
 
+.B optional
+=
+.IR 0 / 1
+(configuration only)
+.IP
+.B Configuration section:
+.br
+If this option is set to 1 the configuration section will only be included in
+the boot menu if the referenced image file exists, and running
+.B zipl
+will not fail if the image file is missing.
+
+The default value for
+.B 'optional'
+is 0.
+.PP
+
 .B parameters
 =
 .I kernel\-parameters

--- a/zipl/src/boot.c
+++ b/zipl/src/boot.c
@@ -391,6 +391,10 @@ store_stage2_menu(void* data, size_t size, struct job_data* job)
 		return 0;
 	/* Config texts */
 	for (i = 0; i < job->data.menu.num; i++) {
+		if (job->data.menu.entry[i].data.ipl.ignore) {
+			params->config[job->data.menu.entry[i].pos] = 0;
+			continue;
+		}
 		const char *kdump_str = "";
 		if (job->data.menu.entry[i].data.ipl.is_kdump)
 			kdump_str = " (kdump)";

--- a/zipl/src/bootmap.c
+++ b/zipl/src/bootmap.c
@@ -1006,6 +1006,12 @@ build_program_table(int fd, struct job_data* job, disk_blockptr_t* pointer,
 		for (i=0; i < job->data.menu.num; i++) {
 			switch (job->data.menu.entry[i].id) {
 			case job_ipl:
+				if (job->data.menu.entry[i].data.ipl.ignore) {
+					printf("Skipping #%d: IPL section '%s' (missing files)\n",
+					       job->data.menu.entry[i].pos,
+					       job->data.menu.entry[i].name);
+					break;
+				}
 				printf("Adding #%d: IPL section '%s'%s",
 				       job->data.menu.entry[i].pos,
 				       job->data.menu.entry[i].name,

--- a/zipl/src/job.c
+++ b/zipl/src/job.c
@@ -1419,7 +1419,7 @@ get_job_from_section_data(char* data[], struct job_data* job, char* section)
 		}
 		job->data.ipl.optional =
 			data[(int) scan_keyword_optional] != NULL ?
-			true : false;
+			atoi(data[(int) scan_keyword_optional]) == 1 : false;
 		job->data.ipl.ignore = false;
 		break;
 	case section_ipl_tape:

--- a/zipl/src/scan.c
+++ b/zipl/src/scan.c
@@ -47,45 +47,45 @@ enum scan_key_state scan_key_table[SCAN_SECTION_NUM][SCAN_KEYWORD_NUM] = {
  *	 ult  to   tofs e    mete file isk  ent  et   pt   out  ultm      dump
  *			     rs                                 enu
  *
- *       targ targ targ targ targ defa kdum secu
- *       etba etty etge etbl etof ulta p    re
+ *       targ targ targ targ targ defa kdum secu opti
+ *       etba etty etge etbl etof ulta p    re   onal
  *       se   pe   omet ocks fset uto
  *                 ry   ize
  */
 /* default auto */
 	{opt, inv, inv, inv, inv, inv, inv, inv, req, opt, opt, inv, inv, inv,
-	 opt, opt, opt, opt, opt, opt, inv, opt},
+	 opt, opt, opt, opt, opt, opt, inv, opt, inv},
 /* default menu */
 	{inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, req, inv, inv,
-	 inv, inv, inv, inv, inv, inv, inv, opt},
+	 inv, inv, inv, inv, inv, inv, inv, opt, inv},
 /* default section */
 	{req, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv,
-	 inv, inv, inv, inv, inv, inv, inv, opt},
+	 inv, inv, inv, inv, inv, inv, inv, opt, inv},
 /* ipl		*/
 	{inv, inv, inv, req, opt, opt, opt, inv, req, inv, inv, inv, inv, inv,
-	 opt, opt, opt, opt, opt, inv, opt, opt},
+	 opt, opt, opt, opt, opt, inv, opt, opt, opt},
 /* segment load */
 	{inv, inv, inv, inv, inv, inv, inv, req, req, inv, inv, inv, inv, inv,
-	 inv, inv, inv, inv, inv, inv, inv, inv},
+	 inv, inv, inv, inv, inv, inv, inv, inv, inv},
 /* part dump	*/
 	{inv, req, inv, inv, inv, inv, inv, inv, opt, inv, inv, inv, inv, inv,
-	 inv, inv, inv, inv, inv, inv, inv, inv},
+	 inv, inv, inv, inv, inv, inv, inv, inv, inv},
 /* fs dump	*/
 	{inv, inv, req, inv, opt, opt, inv, inv, req, inv, inv, inv, inv, inv,
-	 inv, inv, inv, inv, inv, inv, inv, inv},
+	 inv, inv, inv, inv, inv, inv, inv, inv, inv},
 /* ipl tape	*/
 	{inv, inv, inv, req, opt, opt, opt, inv, inv, inv, inv, inv, req, inv,
-	 inv, inv, inv, inv, inv, inv, inv, inv},
+	 inv, inv, inv, inv, inv, inv, inv, inv, inv},
 /* multi volume dump	*/
 	{inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, inv, req,
-	 inv, inv, inv, inv, inv, inv, inv, inv}
+	 inv, inv, inv, inv, inv, inv, inv, inv, inv}
 };
 
 /* Determines which keyword may be present in a menu section */
 enum scan_key_state scan_menu_key_table[SCAN_KEYWORD_NUM] = {
 /* menu section */
 	 opt, inv, inv, inv, inv, inv, inv, inv, req, opt, opt, inv, inv, inv,
-	 opt, opt, opt, opt, opt, inv, inv, opt
+	 opt, opt, opt, opt, opt, inv, inv, opt, inv
 };
 
 /* Mapping of keyword IDs to strings */
@@ -114,6 +114,7 @@ static const struct {
 	{ "tape", scan_keyword_tape},
 	{ "kdump", scan_keyword_kdump},
 	{ "secure", scan_keyword_secure},
+	{ "optional", scan_keyword_optional},
 };
 
 /* List of keywords that are used without an assignment */


### PR DESCRIPTION
Debian carried a patch forever that allowed zipl to run even if not all
menu items had files attached. If a required file is missing for an
entry (e.g. vmlinuz.old or initrd.img.old) and it is marked as "optional"
in the config, the section will be skipped. This allows to zipl to install
after bootstraping, as booting on s390 still relies on the kernel/initrd
symlinks in the root directory.

Signed-off-by: Philipp Kern <pkern@debian.org>