### PR TITLE
zipl: fix the scanned tokens array size calculation

### DIFF
--- a/zipl/src/scan.c
+++ b/zipl/src/scan.c
@@ -755,8 +755,14 @@ scan_bls(const char* blsdir, struct scan_token** token, int scan_size)
 
 	remaining = scan_size - count;
 
-	if (remaining < n) {
-		size = scan_size - remaining + n;
+	/* The array of scanned tokens is allocated when the zipl config file is
+	 * parsed. Its size is a multiple of INITIAL_ARRAY_LENGTH so it may have
+	 * enough space to scan all the tokens that are defined in the BLS files.
+	 * Calculate if is enough assuming that a BLS fragment can contain up to
+	 * 4 tokens: a section heading and 3 keywords (image, ramdisk, parameter).
+	 */
+	if (remaining < n * 4) {
+		size = scan_size - remaining + (n * 4);
 		buffer = (struct scan_token *)misc_malloc(size * sizeof(struct scan_token));
 		if (!buffer)
 			goto err;


### PR DESCRIPTION
The zipl config file (zipl.conf) and the BootLoaderSpec (BLS) fragments
in /boot/loader/entries define a set of tokens that are parsed by zipl.

These are stored in an array of tokens whose size is calculated to make
sure that there is enough memory allocated for all the scanned tokens.

But the size calculation logic was wrong, since it was checking if the
current size was enough to store a single token per BLS fragment, while
up to 4 tokens can be defined in a BLS file: a section heading and the
image, ramdisk and parameter keywords.

This led to zipl being killed by a SIGABRT signal when trying to parse
more tokens than the ones that could fit in the scanned tokens array:

Using config file '/etc/zipl.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-9.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-8.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-7.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-6.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-5.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-4.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-3.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-2.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-1.conf'
Using BLS config file '/boot/loader/entries/vmlinuz-0.conf'
double free or corruption (out)
Aborted (core dumped)

Fixes: https://github.com/ibm-s390-tools/s390-tools/issues/68
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>