### PR TITLE
dumpconf: Don't run the service in LXC

### DIFF
--- a/systemd/dumpconf.service.in
+++ b/systemd/dumpconf.service.in
@@ -9,6 +9,7 @@
 
 [Unit]
 Description=Configure dump on panic for System z
+ConditionVirtualization=!lxc
 After=network.target
 
 [Service]


### PR DESCRIPTION
It just fails to start in unprivileged containers

Signed-off-by: Balint Reczey <balint.reczey@canonical.com>