### PR TITLE
osasnmpd/Makefile: fix cross-compilation

### DIFF
--- a/osasnmpd/Makefile
+++ b/osasnmpd/Makefile
@@ -1,9 +1,10 @@
 include ../common.mak
-LDLIBS = `net-snmp-config --agent-libs`
+NET_SNMP_CONFIG = net-snmp-config
+LDLIBS = `$(NET_SNMP_CONFIG) --agent-libs`
 # On some Linux systems `net-snmp-config --agent-libs` introduces -pie,
 # therefore add -fPIC to prevent link failures.
 ALL_CFLAGS += -fPIC
-ALL_CFLAGS += `net-snmp-config --cflags`
+ALL_CFLAGS += `$(NET_SNMP_CONFIG) --cflags`
 
 OBJS = ibmOSAMib.o ibmOSAMibUtil.o osasnmpd.o
 


### PR DESCRIPTION
Fix the following build failure by allowing the user to provide NET_SNMP_CONFIG:

```
/bin/sh: net-snmp-config: command not found
/home/buildroot/autobuild/run/instance-2/output-1/host/lib/gcc/s390x-buildroot-linux-gnu/9.3.0/../../../../s390x-buildroot-linux-gnu/bin/ld: osasnmpd.o: in function `main':
osasnmpd.c:(.text.startup+0xcc): undefined reference to `snmp_log_perror'
```

Fixes:
 - http://autobuild.buildroot.org/results/00796f2ebd5fb0e08ac7a05a9ee566f2bc4bd1c3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>