### PR TITLE
zipl/boot/Makefile: -no-pie is not a valid ld flag

### DIFF
--- a/zipl/boot/Makefile
+++ b/zipl/boot/Makefile
@@ -109,7 +109,7 @@ stage3.bin:	stage3.exec
 		$< $@
 
 data.o: $(FILES)
-	$(LD) $(NO_PIE_LDFLAGS) -r -b binary -o data.o $(FILES)
+	$(LD) -r -b binary -o data.o $(FILES)
 
 data.h: data.o
 	rm -f data.h


### PR DESCRIPTION
The "-no-pie" option never has been a valid flag of ld. It breaks the build with newer binutils.
See:
https://sourceware.org/bugzilla/show_bug.cgi?id=27050
https://bugs.launchpad.net/ubuntu/+source/s390-tools/+bug/1907789