### PR TITLE
zipl: fix reading 4k disk's geometry

### DIFF
--- a/zipl/src/disk.c
+++ b/zipl/src/disk.c
@@ -444,6 +444,9 @@ type_determined:
 	}
 	/* Convert device size to size in physical blocks */
 	data->phy_blocks = devsize / (data->phy_block_size / 512);
+	/* Adjust start on SCSI according to block_size. device-mapper devices are skipped */
+	if (data->type == disk_type_scsi && target->targetbase == NULL)
+	        data->geo.start = data->geo.start / (data->phy_block_size / 512);
 	if (data->partnum != 0)
 		data->partition = stats.st_rdev;
 	/* Try to get device name */


### PR DESCRIPTION
Fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1918723

On 4k SCSI disks zipl stores wrong values to 'scsi_mbr.program_table_pointer',
which makes system unbootable.
This happens in 'zipl/src/disk.c:656':

```
/* Convert file system block to physical */
*physical = mapped * phy_per_fs + subblock;
/* Add partition start */
*physical += info->geo.start;

```

So 'hd_geometry.start' should be adjusted before being used.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>