### PR TITLE
Switch to fuse3

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ build options:
 
 | __LIBRARY__    | __BUILD OPTION__   | __TOOLS__                             |
 |----------------|:------------------:|:-------------------------------------:|
-| fuse           | `HAVE_FUSE`        | cmsfs-fuse, zdsfs, hmcdrvfs, zgetdump,|
+| fuse3          | `HAVE_FUSE`        | cmsfs-fuse, zdsfs, hmcdrvfs, zgetdump,|
 |                |                    | hsavmcore                             |
 | zlib           | `HAVE_ZLIB`        | zgetdump, dump2tar                    |
 | ncurses        | `HAVE_NCURSES`     | hyptop                                |
@@ -351,12 +351,12 @@ the different tools are provided:
 
 * cmsfs-fuse/zdsfs/hmcdrvfs/zgetdump:
   The tools cmsfs-fuse, zdsfs, hmcdrvfs, and zgetdump depend on FUSE.
-  FUSE is provided by installing the fuse and libfuse packages and by a
+  FUSE is provided by installing the fuse3 and libfuse3 packages and by a
   kernel compiled with `CONFIG_FUSE_FS`. For compiling the s390-tools package
-  the fuse-devel package is required.
-  The cmsfs-fuse tool requires FUSE version 2.8.1 or newer for full
+  the fuse3-devel package is required.
+  The cmsfs-fuse tool requires FUSE version 3.0 or newer for full
   functionality.
-  For further information about FUSE see: http://fuse.sourceforge.net
+  For further information about FUSE see: https://github.com/libfuse/libfuse
 
 * hyptop:
   The ncurses-devel package is required to build hyptop.
@@ -452,7 +452,7 @@ the different tools are provided:
   `HAVE_JSONC=0`, or `HAVE_LIBCURL=0` to the make invocation.
 
 * hsavmcore:
-  For building the hsavmcore tool you need fuse version 2.6 and optionally
+  For building the hsavmcore tool you need fuse version 3.0 and optionally
   systemd which is enabled by default, to disable systemd support,
   add `HAVE_SYSTEMD=0` to the make invocation.
   Tip: you may skip the hsavmcore build by adding `HAVE_FUSE=0`

--- a/cmsfs-fuse/Makefile
+++ b/cmsfs-fuse/Makefile
@@ -16,17 +16,18 @@ check_dep:
 	$(call check_dep, \
 		"cmsfs-fuse", \
 		"fuse.h", \
-		"fuse-devel or libfuse-dev", \
-		"HAVE_FUSE=0")
+		"fuse3-devel or libfuse3-dev", \
+		"HAVE_FUSE=0", \
+		"-DFUSE_USE_VERSION=30")
 
 all: check_dep cmsfs-fuse
 
 ifneq ($(shell sh -c 'command -v pkg-config'),)
-FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse)
-FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse)
+FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse3)
+FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse3)
 else
-FUSE_CFLAGS = -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse
-FUSE_LDLIBS = -lfuse
+FUSE_CFLAGS = -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse3
+FUSE_LDLIBS = -lfuse3
 endif
 ALL_CFLAGS += -DHAVE_SETXATTR $(FUSE_CFLAGS)
 LDLIBS += $(FUSE_LDLIBS) -lm

--- a/cmsfs-fuse/cmsfs-fuse.1
+++ b/cmsfs-fuse/cmsfs-fuse.1
@@ -80,9 +80,6 @@ Allow access by other users
 \fB\-o\fR allow_root
 Allow access by root
 .TP
-\fB\-o\fR nonempty
-Allow mounts over non\-empty file/dir
-.TP
 \fB\-o\fR default_permissions 
 Enable permission checking by kernel
 .TP

--- a/cmsfs-fuse/cmsfs-fuse.c
+++ b/cmsfs-fuse/cmsfs-fuse.c
@@ -9,7 +9,7 @@
  * it under the terms of the MIT license. See LICENSE for details.
  */
 
-#define FUSE_USE_VERSION 26
+#define FUSE_USE_VERSION 30
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
@@ -1516,7 +1516,7 @@ static void walk_dir_block(struct fst_entry *fst, struct walk_file *walk,
 				decode_edf_name(file, fst->name, fst->type);
 				if (!file_unlinked(file)) {
 					cache_fst_addr(walk->addr, file);
-					walk->filler(walk->buf, file, NULL, 0);
+					walk->filler(walk->buf, file, NULL, 0, 0);
 				}
 			}
 		}
@@ -1800,8 +1800,8 @@ static int cmsfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	if (strcmp(path, "/") != 0)
 		return -ENOENT;
 
-	filler(buf, ".", NULL, 0);
-	filler(buf, "..", NULL, 0);
+	filler(buf, ".", NULL, 0, 0);
+	filler(buf, "..", NULL, 0, 0);
 
 	memset(&walk, 0, sizeof(walk));
 	/* readdir is possible without open so fi->fh is not set */

--- a/hmcdrvfs/Makefile
+++ b/hmcdrvfs/Makefile
@@ -16,17 +16,17 @@ check_dep:
 	$(call check_dep, \
 		"hmcdrvfs", \
 		"fuse.h", \
-		"fuse-devel or libfuse-dev", \
+		"fuse3-devel or libfuse3-dev", \
 		"HAVE_FUSE=0")
 
 ifneq ($(shell sh -c 'command -v pkg-config'),)
-FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse)
-FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse)
+FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse3)
+FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse3)
 else
-FUSE_CFLAGS = -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse
-FUSE_LDLIBS = -lfuse
+FUSE_CFLAGS = -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse3
+FUSE_LDLIBS = -lfuse3
 endif
-ALL_CFLAGS += -DFUSE_USE_VERSION=26 -D_LARGEFILE_SOURCE $(FUSE_CFLAGS)
+ALL_CFLAGS += -DFUSE_USE_VERSION=30 -D_LARGEFILE_SOURCE $(FUSE_CFLAGS)
 LDLIBS += $(FUSE_LDLIBS) -lpthread -lrt -ldl -lm
 
 OBJECTS = hmcdrvfs.o

--- a/hmcdrvfs/hmcdrvfs.1
+++ b/hmcdrvfs/hmcdrvfs.1
@@ -111,9 +111,6 @@ allow access by other users
 .B -o allow_root
 allow access by root
 .TP
-.B -o nonempty
-allow mounts over non-empty file/dir
-.TP
 .B -o default_permissions
 enable permission checking by kernel
 .TP

--- a/hmcdrvfs/hmcdrvfs.c
+++ b/hmcdrvfs/hmcdrvfs.c
@@ -990,7 +990,7 @@ static int hmcdrv_cache_dir(const char *dir, fuse_fill_dir_t filler, void *buf)
 				hmcdrv_cache_refresh(path, &st, symlink);
 
 				if ((filler != NULL) &&
-				    (filler(buf, fname, &st, 0) != 0))
+				    (filler(buf, fname, &st, 0, 0) != 0))
 					filler = NULL; /* stop filling */
 #ifdef DEBUG
 				strftime(symlink, sizeof(symlink),
@@ -1179,8 +1179,8 @@ static int hmcdrv_fuse_readdir(const char *path, void *buf,
 {
 	int ret;
 
-	filler(buf, ".", NULL, 0);
-	filler(buf, "..", NULL, 0);
+	filler(buf, ".", NULL, 0, 0);
+	filler(buf, "..", NULL, 0, 0);
 
 	pthread_mutex_lock(&hmcdrv_ctx.mutex);
 	ret = hmcdrv_cache_dir(path, filler, buf);

--- a/hmcdrvfs/hmcdrvfs.c
+++ b/hmcdrvfs/hmcdrvfs.c
@@ -1109,7 +1109,8 @@ static struct hmcdrv_fuse_file *hmcdrv_file_get(const char *path)
  *
  * Note: The most important function which FUSE calls (very often).
  */
-static int hmcdrv_fuse_getattr(const char *path, struct stat *stbuf)
+static int hmcdrv_fuse_getattr(const char *path, struct stat *stbuf,
+			       struct fuse_file_info *UNUSED(fi))
 {
 	struct hmcdrv_fuse_file *fp;
 	int rc = 0;
@@ -1175,7 +1176,8 @@ static int hmcdrv_fuse_opendir(const char *UNUSED(path),
  */
 static int hmcdrv_fuse_readdir(const char *path, void *buf,
 			       fuse_fill_dir_t filler, off_t UNUSED(offset),
-			       struct fuse_file_info *UNUSED(fi))
+			       struct fuse_file_info *UNUSED(fi),
+			       enum fuse_readdir_flags UNUSED(flags))
 {
 	int ret;
 
@@ -1232,7 +1234,8 @@ static int hmcdrv_fuse_read(const char *path, char *buf, size_t size,
  * Return: value to be passed in the private_data field of fuse_context to
  *         all file operations and as a parameter to the destroy() method
  */
-static void *hmcdrv_fuse_init(struct fuse_conn_info *UNUSED(conn))
+static void *hmcdrv_fuse_init(struct fuse_conn_info *UNUSED(conn),
+			      struct fuse_config *UNUSED(cfg))
 {
 	pthread_mutexattr_t attr;
 

--- a/hsavmcore/Makefile
+++ b/hsavmcore/Makefile
@@ -23,11 +23,11 @@ else # HAVE_FUSE
 # FUSE
 #
 ifneq ($(shell sh -c 'command -v pkg-config'),)
-  FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse)
-  FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse)
+  FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse3)
+  FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse3)
 else
-  FUSE_CFLAGS = -I/usr/include/fuse
-  FUSE_LDLIBS = -lfuse
+  FUSE_CFLAGS = -I/usr/include/fuse3
+  FUSE_LDLIBS = -lfuse3
 endif
 
 #
@@ -67,8 +67,9 @@ check-dep-fuse:
 	$(call check_dep, \
 		"hsavmcore", \
 		"fuse.h", \
-		"fuse-devel or libfuse-dev", \
-		"HAVE_FUSE=0")
+		"fuse3-devel or libfuse3-dev", \
+		"HAVE_FUSE=0", \
+		"-DFUSE_USE_VERSION=30")
 	touch check-dep-fuse
 
 install: all

--- a/hsavmcore/initramfs/fedora-rhel/README.md
+++ b/hsavmcore/initramfs/fedora-rhel/README.md
@@ -15,7 +15,7 @@ sudo reboot
 ## Dependencies
 
 ```shell
-sudo dnf install -y fuse fuse-devel systemd-devel
+sudo dnf install -y fuse3 fuse3-devel systemd-devel
 ```
 
 ## Build hsavmcore

--- a/hsavmcore/initramfs/sles/README.md
+++ b/hsavmcore/initramfs/sles/README.md
@@ -18,7 +18,7 @@ sudo reboot
 ## Dependencies
 
 ```shell
-sudo zypper install -y fuse fuse-devel systemd-devel
+sudo zypper install -y fuse3 fuse3-devel systemd-devel
 ```
 
 ## Build hsavmcore

--- a/hsavmcore/initramfs/ubuntu/README.md
+++ b/hsavmcore/initramfs/ubuntu/README.md
@@ -11,7 +11,7 @@
 ## Dependencies
 
 ```shell
-sudo apt-get install -y make gcc kdump-tools fuse libfuse-dev libsystemd-dev
+sudo apt-get install -y make gcc kdump-tools fuse3 libfuse3-dev libsystemd-dev
 ```
 
 ## Build hsavmcore

--- a/hsavmcore/overlay.c
+++ b/hsavmcore/overlay.c
@@ -15,7 +15,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#define FUSE_USE_VERSION 26
+#define FUSE_USE_VERSION 30
 #include <fuse.h>
 
 #include "lib/util_log.h"
@@ -63,9 +63,9 @@ static int vmcore_fuse_readdir(const char *path, void *buf,
 		return -ENOENT;
 
 	/* We have only one file */
-	filler(buf, ".", NULL, 0);
-	filler(buf, "..", NULL, 0);
-	filler(buf, VMCORE_FILE, NULL, 0);
+	filler(buf, ".", NULL, 0, 0);
+	filler(buf, "..", NULL, 0, 0);
+	filler(buf, VMCORE_FILE, NULL, 0, 0);
 
 	return 0;
 }

--- a/hsavmcore/overlay.c
+++ b/hsavmcore/overlay.c
@@ -31,8 +31,11 @@ struct vmcore_overlay {
 	bool fuse_debug;
 };
 
-static int vmcore_fuse_getattr(const char *path, struct stat *stbuf)
+static int vmcore_fuse_getattr(const char *path, struct stat *stbuf,
+			       struct fuse_file_info *fi)
 {
+	(void)fi;
+
 	struct vmcore_overlay *overlay = fuse_get_context()->private_data;
 	int ret = 0;
 
@@ -54,10 +57,12 @@ static int vmcore_fuse_getattr(const char *path, struct stat *stbuf)
 
 static int vmcore_fuse_readdir(const char *path, void *buf,
 			       fuse_fill_dir_t filler, off_t offset,
-			       struct fuse_file_info *fi)
+			       struct fuse_file_info *fi,
+			       enum fuse_readdir_flags flags)
 {
 	(void)offset;
 	(void)fi;
+	(void)flags;
 
 	if (strcmp(path, ROOT_DIR) != 0)
 		return -ENOENT;

--- a/zdsfs/Makefile
+++ b/zdsfs/Makefile
@@ -30,8 +30,9 @@ check_dep:
 	$(call check_dep, \
 		"zdsfs", \
 		"fuse.h", \
-		"fuse-devel or libfuse-dev", \
-		"HAVE_FUSE=0")
+		"fuse3-devel or libfuse3-dev", \
+		"HAVE_FUSE=0", \
+		"-DFUSE_USE_VERSION=30")
 	$(call check_dep, \
 		"zdsfs", \
 		"curl/curl.h", \
@@ -39,13 +40,13 @@ check_dep:
 		"HAVE_CURL=0")
 
 ifneq ($(shell sh -c 'command -v pkg-config'),)
-FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse)
-FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse)
+FUSE_CFLAGS = $(shell pkg-config --silence-errors --cflags fuse3)
+FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse3)
 CURL_CFLAGS = $(shell pkg-config --silence-errors --cflags libcurl)
 CURL_LDLIBS = $(shell pkg-config --silence-errors --libs libcurl)
 else
-FUSE_CFLAGS = -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse
-FUSE_LDLIBS = -lfuse
+FUSE_CFLAGS = -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse3
+FUSE_LDLIBS = -lfuse3
 CURL_CFLAGS = -I/usr/include/s390x-linux-gnu/curl
 CURL_LDLIBS = -lcurl
 endif

--- a/zdsfs/zdsfs.1
+++ b/zdsfs/zdsfs.1
@@ -227,9 +227,6 @@ Allow access by other users
 \fB\-o\fR allow_root
 Allow access by root
 .TP
-\fB\-o\fR nonempty
-Allow mounts over non\-empty file/dir
-.TP
 \fB\-o\fR default_permissions
 Enable permission checking by kernel
 .TP

--- a/zdsfs/zdsfs.c
+++ b/zdsfs/zdsfs.c
@@ -8,7 +8,7 @@
  */
 
 /* The fuse version define tells fuse that we want to use the new API */
-#define FUSE_USE_VERSION 26
+#define FUSE_USE_VERSION 30
 
 #include <errno.h>
 #include <fcntl.h>
@@ -544,9 +544,9 @@ static int zdsfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	 * type one: the root directory contains all data sets
 	 */
 	if (strcmp(path, "/") == 0) {
-		filler(buf, ".", NULL, 0);
-		filler(buf, "..", NULL, 0);
-		filler(buf, METADATAFILE, NULL, 0);
+		filler(buf, ".", NULL, 0, 0);
+		filler(buf, "..", NULL, 0, 0);
+		filler(buf, METADATAFILE, NULL, 0, 0);
 		/* note that we do not need to distinguish between
 		 * normal files and directories here, that is done
 		 * in the rdf_getattr function
@@ -558,7 +558,7 @@ static int zdsfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 			lzds_dataset_get_is_supported(ds, &issupported);
 			if (issupported) {
 				lzds_dataset_get_name(ds, &dsname);
-				filler(buf, dsname, NULL, 0);
+				filler(buf, dsname, NULL, 0, 0);
 			}
 		}
 		lzds_dsiterator_free(dsit);
@@ -572,14 +572,14 @@ static int zdsfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 		return -ENOENT;
 	lzds_dataset_get_is_PDS(ds, &ispds);
 	if (ispds) {
-		filler(buf, ".", NULL, 0);
-		filler(buf, "..", NULL, 0);
+		filler(buf, ".", NULL, 0, 0);
+		filler(buf, "..", NULL, 0, 0);
 		rc = lzds_dataset_alloc_memberiterator(ds, &it);
 		if (rc)
 			return -ENOMEM;
 		while (!lzds_memberiterator_get_next_member(it, &member)) {
 			lzds_pdsmember_get_name(member, &mbrname);
-			filler(buf, mbrname, NULL, 0);
+			filler(buf, mbrname, NULL, 0, 0);
 		}
 		lzds_memberiterator_free(it);
 	} else

--- a/zdsfs/zdsfs.c
+++ b/zdsfs/zdsfs.c
@@ -312,7 +312,8 @@ void keepalive_start(void)
 	setup_timer(zdsfsinfo.keepalive);
 }
 
-static int zdsfs_getattr(const char *path, struct stat *stbuf)
+static int zdsfs_getattr(const char *path, struct stat *stbuf,
+			 struct fuse_file_info *UNUSED(fi))
 {
 	char normds[MAXDSNAMELENGTH];
 	size_t dssize;
@@ -524,7 +525,8 @@ static int zdsfs_update_vtoc(void)
 }
 
 static int zdsfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			 off_t UNUSED(offset), struct fuse_file_info *UNUSED(fi))
+			 off_t UNUSED(offset), struct fuse_file_info *UNUSED(fi),
+			 enum fuse_readdir_flags UNUSED(flags))
 {
 	char normds[MAXDSNAMELENGTH];
 	char *mbrname;

--- a/zdump/Makefile
+++ b/zdump/Makefile
@@ -15,8 +15,9 @@ check_dep_fuse:
 	$(call check_dep, \
 		"zgetdump mount support", \
 		"fuse.h", \
-		"fuse-devel or libfuse-dev", \
-		"HAVE_FUSE=0")
+		"fuse3-devel or libfuse3-dev", \
+		"HAVE_FUSE=0", \
+		"-DFUSE_USE_VERSION=30")
 endif
 
 #
@@ -58,11 +59,11 @@ ifeq ("$(HAVE_FUSE)","0")
 FUSE_CFLAGS = -DHAVE_FUSE=0 -D_FILE_OFFSET_BITS=64
 FUSE_LDLIBS =
 else ifneq ($(shell sh -c 'command -v pkg-config'),)
-FUSE_CFLAGS = -DHAVE_FUSE=1 $(shell pkg-config --silence-errors --cflags fuse)
-FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse)
+FUSE_CFLAGS = -DHAVE_FUSE=1 $(shell pkg-config --silence-errors --cflags fuse3)
+FUSE_LDLIBS = $(shell pkg-config --silence-errors --libs fuse3)
 else
-FUSE_CFLAGS = -DHAVE_FUSE=1 -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse
-FUSE_LDLIBS = -lfuse
+FUSE_CFLAGS = -DHAVE_FUSE=1 -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse3
+FUSE_LDLIBS = -lfuse3
 endif
 LDLIBS += -lz $(FUSE_LDLIBS)
 ALL_CFLAGS += $(FUSE_CFLAGS)

--- a/zdump/zfuse.c
+++ b/zdump/zfuse.c
@@ -9,7 +9,7 @@
  * it under the terms of the MIT license. See LICENSE for details.
  */
 
-#define FUSE_USE_VERSION 25
+#define FUSE_USE_VERSION 30
 
 #include <errno.h>
 #include <fcntl.h>
@@ -104,9 +104,9 @@ static int zfuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 	if (strcmp(path, "/") != 0)
 		return -ENOENT;
 
-	filler(buf, ".", NULL, 0);
-	filler(buf, "..", NULL, 0);
-	filler(buf, &l.path[1], NULL, 0);
+	filler(buf, ".", NULL, 0, 0);
+	filler(buf, "..", NULL, 0, 0);
+	filler(buf, &l.path[1], NULL, 0, 0);
 	return 0;
 }
 
@@ -209,7 +209,7 @@ int zfuse_mount_dump(void)
 	stat_root_init();
 	stat_dump_init();
 	snprintf(l.path, sizeof(l.path), "/dump.%s", dfo_name());
-	return fuse_main(args.argc, args.argv, &zfuse_ops);
+	return fuse_main(args.argc, args.argv, &zfuse_ops, NULL);
 }
 
 /*

--- a/zdump/zfuse.c
+++ b/zdump/zfuse.c
@@ -206,7 +206,7 @@ int zfuse_mount_dump(void)
 	fuse_opt_add_arg(&args, "zgetdump");
 	fuse_opt_add_arg(&args, "-s");
 	snprintf(tmp_str, sizeof(tmp_str),
-		 "-ofsname=%s,ro,default_permissions,nonempty",
+		 "-ofsname=%s,ro,default_permissions",
 		 g.opts.device);
 	fuse_opt_add_arg(&args, tmp_str);
 	fuse_opt_add_arg(&args, g.opts.mount_point);

--- a/zdump/zfuse.c
+++ b/zdump/zfuse.c
@@ -79,8 +79,11 @@ static void stat_dump_init(void)
 /*
  * FUSE callback: Getattr
  */
-static int zfuse_getattr(const char *path, struct stat *stat)
+static int zfuse_getattr(const char *path, struct stat *stat,
+			 struct fuse_file_info *fi)
 {
+	(void) fi;
+
 	if (strcmp(path, "/") == 0) {
 		*stat = l.stat_root;
 		return 0;
@@ -96,10 +99,12 @@ static int zfuse_getattr(const char *path, struct stat *stat)
  * FUSE callback: Readdir - Return ".", ".." and dump file
  */
 static int zfuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
-			 off_t offset, struct fuse_file_info *fi)
+			 off_t offset, struct fuse_file_info *fi,
+			 enum fuse_readdir_flags flags)
 {
 	(void) offset;
 	(void) fi;
+	(void) flags;
 
 	if (strcmp(path, "/") != 0)
 		return -ENOENT;


### PR DESCRIPTION
Fuse 3.0.0 was released in December 2016.  The last maintenance release from the 2.9 branch was in January 2019, and users are encourage to transition to the actively developed 3.x branch.
https://github.com/libfuse/libfuse/releases/tag/fuse-2.9.9
Closes #116