### PR TITLE
zipl/boot: Always clear COMMAND_LINE_EXTRA region

### DIFF
--- a/zipl/boot/menu.c
+++ b/zipl/boot/menu.c
@@ -143,12 +143,13 @@ int menu(void)
 	int rc;
 
 	cmd_line_extra = (char *)COMMAND_LINE_EXTRA;
+	memset(cmd_line_extra, 0, COMMAND_LINE_EXTRA_SIZE);
+
 	rc = sclp_setup(SCLP_INIT);
 	if (rc)
 		/* sclp setup failed boot default */
 		goto boot;
 
-	memset(cmd_line_extra, 0, COMMAND_LINE_SIZE);
 	rc = menu_param(&value);
 	if (rc == 0) {
 		/* got number from loadparm, boot it */


### PR DESCRIPTION
Always clear the COMMAND_LINE_EXTRA region, also in case sclp_setup()
fails. If the region is not cleared properly, there might be junk
in there after a reboot, causing confusion for the kernel later.
