### PR TITLE
cpictl: fix permissions

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -20,7 +20,7 @@ install:
 	sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' cpictl > \
 		$(DESTDIR)$(TOOLS_LIBDIR)/cpictl
 	chown $(OWNER):$(GROUP) $(DESTDIR)$(TOOLS_LIBDIR)/cpictl
-	chmod 775 $(DESTDIR)$(TOOLS_LIBDIR)/cpictl
+	chmod 755 $(DESTDIR)$(TOOLS_LIBDIR)/cpictl
 
 	@for i in $(MAN_PAGES); \
 	do \


### PR DESCRIPTION
The regular 0755 permission should be sufficient for cpictl.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2024102

Signed-off-by: Dan Horák <dan@danny.cz>