### PR TITLE
zipl: be verbose about secure boot state

### DIFF
--- a/zipl/src/bootmap.c
+++ b/zipl/src/bootmap.c
@@ -124,15 +124,26 @@ check_secure_boot_support(void)
 	unsigned int val;
 	FILE *fp;
 
+	if (verbose)
+		printf("Secure boot support: ");
+
 	fp = fopen(ZIPL_SIPL_PATH, "r");
-	if (!fp)
+	if (!fp) {
+		if (verbose)
+			printf("not available\n");
 		return false;
+	}
 
 	if (fscanf(fp, "%d", &val) != 1) {
+		if (verbose)
+			printf("error\n");
 		fclose(fp);
 		return false;
 	}
 	fclose(fp);
+
+	if (verbose)
+		printf("%s\n", val ? "yes" : "no");
 
 	return val ? true : false;
 }

--- a/zipl/src/bootmap.c
+++ b/zipl/src/bootmap.c
@@ -36,6 +36,9 @@
 /* Pointer to dedicated empty block in bootmap. */
 static disk_blockptr_t empty_block;
 
+/* State of secure boot in the system */
+static bool secure_boot_supported;
+
 /* Get size of a bootmap block pointer for disk with given INFO. */
 static int
 get_blockptr_size(struct disk_info* info)
@@ -539,7 +542,6 @@ static int add_ipl_program(int fd, char *filename,
 	struct component_loc comp_loc[10];
 	struct signature_header sig_head;
 	size_t ramdisk_size, image_size;
-	bool secure_boot_supported;
 	size_t stage3_params_size;
 	const char *comp_name[11];
 	size_t signature_size;
@@ -628,7 +630,6 @@ static int add_ipl_program(int fd, char *filename,
 		return -1;
 	}
 	image_size = stats.st_size;
-	secure_boot_supported = check_secure_boot_support();
 	signature_size = extract_signature(ZIPL_STAGE3_PATH, &signature,
 					   &sig_head);
 	if (signature_size &&
@@ -1206,6 +1207,8 @@ bootmap_create(struct job_data *job, disk_blockptr_t *program_table,
 	size_t stage2_size;
 	void *stage2_data;
 	int fd, rc, part_ext;
+
+	secure_boot_supported = check_secure_boot_support();
 
 	/* Get full path of bootmap file */
 	if (job->id == job_dump_partition && !dry_run) {


### PR DESCRIPTION
When trying to understand what's going on in https://bugzilla.redhat.com/show_bug.cgi?id=2089134 (IBM LTC bz 198327) where the secure boot boot record is not always written, I found it would be good have zipl to report the state of secure boot support on the system.