### PR TITLE
README.md: Add 70-chreipl-fcp-mpath.rules to the list of udev rule descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Package contents
    - 40-z90crypt.rules: udev rules for z90crypt driver
    - 90-cpi.rules: udev rule to update Control-Program-Information when KVM is
                    used.
+   - 70-chreipl-fcp-mpath.rules: udev rules to monitor multipath events for
+                                 re-IPL path failover and to adjust the re-IPL
+                                 device in case needed.
 
  * systemd units:
    - cpi.service: Unit to apply CPI settings


### PR DESCRIPTION
All udev rules that are part of the s390-tools package are listed in the main
README.md with a brief description.
This commit adds information about the newly added rule for chreipl-fcp-mpath,
called '70-chreipl-fcp-mpath.rules'.

Signed-off-by: Frank Heimes <frank.heimes@canonical.com>