### PR TITLE
zkey: use default benchmarked Argon2i with LUKS2

### DIFF
--- a/zkey/keystore.c
+++ b/zkey/keystore.c
@@ -4312,15 +4312,16 @@ static int _keystore_process_cryptsetup(struct keystore *keystore,
 			}
 		} else {
 			/*
-			 * Use PBKDF2 as key derivation function for LUKS2
-			 * volumes. LUKS2 uses Argon2i as default, but this
-			 * might cause out-of-memory errors when multiple LUKS2
-			 * volumes are opened automatically via /etc/crypttab
+			 * Use Argon2i as key derivation function for LUKS2
+			 * volumes, but with options for low memory and time requirements. 
+			 * Using the default Argon2i options might cause out-of-memory
+			 * errors when multiple LUKS2 volumes are opened automatically 
+			 * via /etc/crypttab
 			 */
 			util_asprintf(&cmd,
 				      "cryptsetup luksFormat %s%s--type luks2 "
 				      "--master-key-file '%s' --key-size %lu "
-				      "--cipher %s --pbkdf pbkdf2 %s%s%s",
+				      "--cipher %s --pbkdf argon2i --pbkdf-memory 32 --pbkdf-force-iterations 4 %s%s%s",
 				      info->batch_mode ? "-q " : "",
 				      keystore->verbose ? "-v " : "",
 				      key_file_name, key_file_size * 8,

--- a/zkey/zkey.1
+++ b/zkey/zkey.1
@@ -734,13 +734,12 @@ type, this is the default. If specified for the plain volume type, then no
 command is generated.
 .P
 For LUKS2 volumes, the generated \fBcryptsetup luksFormat\fP contains
-option \fB\-\-pbkdf pbkdf2\fP to set \fBPBKDF2\fP as password based key
-derivation function. LUKS2 volumes typically default to \fBArgon2i\fP as
-password based key derivation function, but this might cause out-of-memory
-errors when multiple encrypted volumes are unlocked automatically at boot
-through /etc/crypttab. Because PAES uses secure AES keys as volume keys, the
-security of the key derivation function used to encrypt the volume key in the
-LUKS key slots is of less relevance. 
+options \fB-\-pbkdf argon2i \-\-pbkdf\-memory 32 \-\-pbkdf\-force\-iterations 4
+\fP for low memory and time requirements. Using the default \fBArgon2i\fP
+options might cause out-of-memory errors when multiple encrypted volumes are
+unlocked automatically at boot through /etc/crypttab. Because PAES uses secure
+AES keys as volume keys, the security of the key derivation function used to encrypt
+the volume key in the LUKS key slots is of less relevance. 
 .P
 For LUKS2 volumes, a passphrase is required. You are prompted for the
 passphrase when running the generated commands, unless option


### PR DESCRIPTION
Argon2i is not only the winner of Password Hashing Competition,
it's meanwhile also officially recommended by RFC 9106.
So for Ubuntu we moved back from '--pbkdf pbkdf2' to the default (argon2i) a while ago.

The PR is to raise the discussion if this should not be generally the case?

More details can be found the rational can be found here:
https://bugs.launchpad.net/bugs/1820049
https://github.com/systemd/systemd/pull/14168
https://gitlab.com/cryptsetup/cryptsetup/-/issues/446
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=924560