### PR TITLE
fix Makefile install step chown warnings

### DIFF
--- a/ap_tools/Makefile
+++ b/ap_tools/Makefile
@@ -26,9 +26,9 @@ ap-check: ap-check.o $(libs)
 install: all
 	@if [ ! -d $(DESTDIR)$(MDEVCTL_CALLOUTS) ]; then \
 		mkdir -p $(DESTDIR)$(MDEVCTL_CALLOUTS); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MDEVCTL_DIR); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MDEVCTL_SCRIPTS); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MDEVCTL_CALLOUTS); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MDEVCTL_DIR); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MDEVCTL_SCRIPTS); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MDEVCTL_CALLOUTS); \
 		chmod 755 $(DESTDIR)$(MDEVCTL_DIR); \
 		chmod 755 $(DESTDIR)$(MDEVCTL_SCRIPTS); \
 		chmod 755 $(DESTDIR)$(MDEVCTL_CALLOUTS); \
@@ -37,9 +37,9 @@ install: all
 		$(DESTDIR)$(MDEVCTL_CALLOUTS)
 	@if [ ! -d $(DESTDIR)$(MDEVCTL_DEP_CALLOUTS) ]; then \
 		mkdir -p $(DESTDIR)$(MDEVCTL_DEP_CALLOUTS); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MDEVCTL_DEP_DIR); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MDEVCTL_DEP_SCRIPTS); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MDEVCTL_DEP_CALLOUTS); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MDEVCTL_DEP_DIR); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MDEVCTL_DEP_SCRIPTS); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MDEVCTL_DEP_CALLOUTS); \
 		chmod 755 $(DESTDIR)$(MDEVCTL_DEP_DIR); \
 		chmod 755 $(DESTDIR)$(MDEVCTL_DEP_SCRIPTS); \
 		chmod 755 $(DESTDIR)$(MDEVCTL_DEP_CALLOUTS); \

--- a/hmcdrvfs/Makefile
+++ b/hmcdrvfs/Makefile
@@ -52,7 +52,7 @@ install-scripts: lshmc
 		cat $$i | \
 		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(USRSBINDIR)/$$i; \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(USRSBINDIR)/$$i; \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(USRSBINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(USRSBINDIR)/$$i; \
 	done
 

--- a/hsci/Makefile
+++ b/hsci/Makefile
@@ -5,7 +5,7 @@ all:
 install: hsci
 	$(SED) -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 	< hsci >$(DESTDIR)$(BINDIR)/hsci; \
-	chown $(OWNER).$(GROUP) $(DESTDIR)$(BINDIR)/hsci; \
+	chown $(OWNER):$(GROUP) $(DESTDIR)$(BINDIR)/hsci; \
 	chmod 755 $(DESTDIR)$(BINDIR)/hsci; \
 	$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man8
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 644 hsci.8 \

--- a/ip_watcher/Makefile
+++ b/ip_watcher/Makefile
@@ -12,7 +12,7 @@ clean:
 install: ip_watcher.pl xcec-bridge start_hsnc.sh
 	$(SED) -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 	< start_hsnc.sh >$(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \
-	chown $(OWNER).$(GROUP) $(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \
+	chown $(OWNER):$(GROUP) $(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \
 	chmod 755 $(DESTDIR)$(USRSBINDIR)/start_hsnc.sh; \
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 755 ip_watcher.pl \
 		$(DESTDIR)$(USRSBINDIR)

--- a/netboot/Makefile
+++ b/netboot/Makefile
@@ -15,13 +15,13 @@ install: install-scripts
 install-scripts: $(SCRIPTS)
 	@if [ ! -d $(DESTDIR)$(NETBOOT_SAMPLEDIR) ]; then \
 		mkdir -p $(DESTDIR)$(NETBOOT_SAMPLEDIR); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(NETBOOT_SAMPLEDIR); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(NETBOOT_SAMPLEDIR); \
 		chmod 755 $(DESTDIR)$(NETBOOT_SAMPLEDIR); \
 	fi; \
 	for i in $^; do \
 		$(SED) -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		< $$i >$(DESTDIR)$(NETBOOT_SAMPLEDIR)/$$i; \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(NETBOOT_SAMPLEDIR)/$$i; \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(NETBOOT_SAMPLEDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(NETBOOT_SAMPLEDIR)/$$i; \
 	done
 

--- a/qethconf/Makefile
+++ b/qethconf/Makefile
@@ -5,7 +5,7 @@ all:
 install: qethconf
 	$(SED) -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 	< qethconf >$(DESTDIR)$(BINDIR)/qethconf; \
-	chown $(OWNER).$(GROUP) $(DESTDIR)$(BINDIR)/qethconf; \
+	chown $(OWNER):$(GROUP) $(DESTDIR)$(BINDIR)/qethconf; \
 	chmod 755 $(DESTDIR)$(BINDIR)/qethconf; \
 	$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man8
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 644 qethconf.8 \

--- a/zconf/Makefile
+++ b/zconf/Makefile
@@ -25,7 +25,7 @@ install-scripts:	$(SCRIPTS)
 		cat $$i | \
 		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(BINDIR)/$$i; \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(BINDIR)/$$i; \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(BINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(BINDIR)/$$i; \
 	done
 
@@ -34,15 +34,15 @@ install-usrsbin-scripts:	$(USRSBIN_SCRIPTS)
 		cat $$i | \
 		sed -e 's/%S390_TOOLS_VERSION%/$(S390_TOOLS_RELEASE)/' \
 		>$(DESTDIR)$(USRSBINDIR)/$$i; \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(USRSBINDIR)/$$i; \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(USRSBINDIR)/$$i; \
 		chmod 755 $(DESTDIR)$(USRSBINDIR)/$$i; \
 	done
 
 install-manpages:	$(MANPAGES)
 	@if [ ! -d $(DESTDIR)$(MANDIR) ]; then \
 		mkdir -p $(DESTDIR)$(MANDIR)/man8; \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MANDIR); \
-		chown $(OWNER).$(GROUP) $(DESTDIR)$(MANDIR)/man8; \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MANDIR); \
+		chown $(OWNER):$(GROUP) $(DESTDIR)$(MANDIR)/man8; \
 		chmod 755 $(DESTDIR)$(MANDIR); \
 		chmod 755 $(DESTDIR)$(MANDIR)/man8; \
 	fi; \


### PR DESCRIPTION
Since coreutils v9.1 commit 8f31074cb ("chown: warn about USER.GROUP") chown utility now warns about using of wrong separator for USER and GROUP options.

signed-off: Nikolay Gueorguiev <nikolay.gueorguiev@suse.com>