### PR TITLE
fix permissions in /usr/include

### DIFF
--- a/libekmfweb/Makefile
+++ b/libekmfweb/Makefile
@@ -98,7 +98,7 @@ install-libekmfweb.so.$(VERSION): libekmfweb.so.$(VERSION)
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 755 -T libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERSION)
 	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERM)
 	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so
-	$(INSTALL) -d -m 770 $(DESTDIR)$(USRINCLUDEDIR)/ekmfweb
+	$(INSTALL) -d -m 755 $(DESTDIR)$(USRINCLUDEDIR)/ekmfweb
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 644 $(rootdir)include/ekmfweb/ekmfweb.h $(DESTDIR)$(USRINCLUDEDIR)/ekmfweb
 
 install: all $(INSTALL_TARGETS)

--- a/libkmipclient/Makefile
+++ b/libkmipclient/Makefile
@@ -121,7 +121,7 @@ install-libkmipclient.so.$(VERSION): libkmipclient.so.$(VERSION)
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 755 -T libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERSION)
 	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERM)
 	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so
-	$(INSTALL) -d -m 770 $(DESTDIR)$(USRINCLUDEDIR)/kmipclient
+	$(INSTALL) -d -m 755 $(DESTDIR)$(USRINCLUDEDIR)/kmipclient
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 644 $(rootdir)include/kmipclient/kmipclient.h $(DESTDIR)$(USRINCLUDEDIR)/kmipclient
 
 install: all $(INSTALL_TARGETS)


### PR DESCRIPTION
Fix directory permissions in /usr/include.

`rpmlint` run against Fedora rpms complains about
````
...
s390utils-devel.s390x: E: non-standard-dir-perm /usr/include/ekmfweb 770
s390utils-devel.s390x: E: non-standard-dir-perm /usr/include/kmipclient 770
...
````