### PR TITLE
chreipl: impove disk type detection when running under QEMU

### DIFF
--- a/ipl_tools/ccw.c
+++ b/ipl_tools/ccw.c
@@ -9,7 +9,6 @@
  * it under the terms of the MIT license. See LICENSE for details.
  */
 
-#include <assert.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +16,7 @@
 #include <unistd.h>
 
 #include "lib/util_path.h"
+#include "lib/util_panic.h"
 #include "ipl_tools.h"
 
 /*
@@ -26,9 +26,10 @@
  */
 static int device_sysfs_path(const char *device, char *path, const size_t path_size)
 {
-	assert(device);
-	assert(path);
-	assert(path_size == PATH_MAX);
+	util_assert(device != NULL, "Internal error: device is NULL");
+	util_assert(path != NULL, "Internal error: path is NULL");
+	util_assert(path_size == PATH_MAX, "Internal error: path_size is '%zu', but must be '%zu'",
+		    path_size, PATH_MAX);
 	char *buf = util_path_sysfs("block/%s/device", device);
 
 	if (!realpath(buf, path)) {
@@ -61,6 +62,26 @@ int ccw_is_device(const char *busid)
 	snprintf(path, sizeof(path), "/sys/bus/ccw/drivers/dasd-fba/%s", busid);
 	if (access(path, R_OK) == 0)
 		return 1;
+	return 0;
+}
+
+/*
+ * Check if the specified device is a valid virtio subchannel device
+ */
+int ccw_is_virtio_device(const char *device)
+{
+	char path[PATH_MAX] = { '\0' };
+	unsigned virtio = 0;
+
+	if (device_sysfs_path(device, path, sizeof(path)) != 0)
+		return -1;
+
+	/*
+	 * The output has the following format:
+	 * /sys/devices/css0/0.0.0000/0.0.0000/virtio0/block/vda
+	 */
+	if (sscanf(path, "/sys/devices/css0/%*[0-9a-f.]/%*[0-9a-f.]/virtio%u", &virtio) != 1)
+		return -1;
 	return 0;
 }
 

--- a/ipl_tools/cmd_chreipl.c
+++ b/ipl_tools/cmd_chreipl.c
@@ -391,7 +391,8 @@ static void dev_from_part_nvme(char *dev_name)
 static int set_reipl_type(const char *dev_name)
 {
 	if (strncmp(dev_name, "dasd", strlen("dasd")) == 0 ||
-	    strncmp(dev_name, "vd", strlen("vd")) == 0)
+	    strncmp(dev_name, "vd", strlen("vd")) == 0 ||
+	    ccw_is_virtio_device(dev_name) == 0)
 		l.reipl_type = REIPL_CCW;
 	else if (strncmp(dev_name, "sd", strlen("sd")) == 0)
 		l.reipl_type = REIPL_FCP;

--- a/ipl_tools/ipl_tools.h
+++ b/ipl_tools/ipl_tools.h
@@ -87,6 +87,7 @@ int nvme_is_device(char *fid_str, char *nsid_str);
  * CCW
  */
 extern int ccw_is_device(const char *devno);
+extern int ccw_is_virtio_device(const char *device);
 extern void ccw_busid_get(const char *device, char *devno);
 
 /*


### PR DESCRIPTION
User can attach disk with smth like: "-device virtio-scsi-ccw,... -device scsi-hd,...", so virtio block device appears as '/dev/sda' instead of '/dev/vda'. chreipl assumes all '/dev/sd*' disks as FCP disks, which is not a case in such setup.