### PR TITLE
Fix missing semicolon

### DIFF
--- a/osasnmpd/ibmOSAMib.h
+++ b/osasnmpd/ibmOSAMib.h
@@ -16,7 +16,7 @@
 
 /* we may use header_generic and header_simple_table from the util_funcs module */
 
-config_require(util_funcs)
+config_require(util_funcs);
 
 
 /* function prototypes */


### PR DESCRIPTION
5.9.4 net-snmp started to require semicolon on the config_require there are no docs covering this change. Noticed via [RHBZ#2235734](https://bugzilla.redhat.com/show_bug.cgi?id=2235734)