### PR TITLE
Fix build with libxml2-2.12.0

### DIFF
--- a/libkmipclient/kmip.h
+++ b/libkmipclient/kmip.h
@@ -16,6 +16,7 @@
 #include <openssl/ssl.h>
 
 #include <json-c/json.h>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <curl/curl.h>
 


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.12.0

"Several cyclic dependencies in public header files were fixed. As a result, certain headers won't include other headers as before."

Compare build results:

unpatched: https://koji.fedoraproject.org/koji/taskinfo?taskID=109774742
patched: https://koji.fedoraproject.org/koji/taskinfo?taskID=110257790

/cc @sharkcz 