### PR TITLE
correct mapping of ATTESTATION_NR when uvdevice doesn't support info IOCTL

### DIFF
--- a/rust/pv_core/src/uvdevice/info.rs
+++ b/rust/pv_core/src/uvdevice/info.rs
@@ -48,10 +48,14 @@ impl UvDeviceInfo {
         let mut cmd = uvio_uvdev_info::new_zeroed();
         match uv.send_cmd(&mut cmd) {
             Ok(_) => Ok(cmd.into()),
-            Err(crate::Error::Io(e)) if e.raw_os_error() == Some(libc::ENOTTY) => Ok(Self {
-                supp_uvio_cmds: (UvDevice::ATTESTATION_NR as u64).into(),
+            Err(crate::Error::Io(e)) if e.raw_os_error() == Some(libc::ENOTTY) => {
+            let mut supp_uvio_cmds : Lsb0Flags64 = 0u64.into();
+            supp_uvio_cmds.set_bit(UvDevice::ATTESTATION_NR);
+
+            Ok(Self {
+                supp_uvio_cmds: supp_uvio_cmds,
                 supp_uv_cmds: None,
-            }),
+            })},
             Err(e) => Err(e),
         }
     }

--- a/rust/pv_core/src/uvdevice/info.rs
+++ b/rust/pv_core/src/uvdevice/info.rs
@@ -49,7 +49,7 @@ impl UvDeviceInfo {
         match uv.send_cmd(&mut cmd) {
             Ok(_) => Ok(cmd.into()),
             Err(crate::Error::Io(e)) if e.raw_os_error() == Some(libc::ENOTTY) => {
-            let mut supp_uvio_cmds : Lsb0Flags64 = 0u64.into();
+            let mut supp_uvio_cmds = Lsb0Flags64::default();
             supp_uvio_cmds.set_bit(UvDevice::ATTESTATION_NR);
 
             Ok(Self {


### PR DESCRIPTION
UvDevice::ATTESTATION_NR was used to set the supported uv commands as a value directly, which led to *bit* 0 being set.

As a result, the library (UvDeviceInfo via Display)  reported that `Info` was supported. 
 