### PR TITLE
libpv: fix build with OpenSSL 1.1

### DIFF
--- a/genprotimg/src/utils/crypto.c
+++ b/genprotimg/src/utils/crypto.c
@@ -768,7 +768,7 @@ static X509_NAME *x509_armonk_locality_fixup(const X509_NAME *name)
 					 PV_IBM_Z_SUBJECT_LOCALITY_NAME_ARMONK))
 		return NULL;
 
-	ret = X509_NAME_dup(name);
+	ret = X509_NAME_dup((X509_NAME *)name);
 	if (!ret)
 		g_abort();
 

--- a/libpv/cert.c
+++ b/libpv/cert.c
@@ -1383,7 +1383,7 @@ static X509_NAME *x509_armonk_locality_fixup(const X509_NAME *name)
 					 PV_IBM_Z_SUBJECT_LOCALITY_NAME_ARMONK))
 		return NULL;
 
-	ret = X509_NAME_dup(name);
+	ret = X509_NAME_dup((X509_NAME *)name);
 	if (!ret)
 		g_abort();
 


### PR DESCRIPTION
OpenSSL 1.1 seems to use a non-const parameter to `X509_name_dup()`, but `x509_armonk_locality_fixup()` is passing a const there. The compile then fails on "discards 'const' qualifier", when `-Werror` is used. Thus resolve with a type-cast like in `pv_c2b_name()`.