### PR TITLE
Fixed typos in code and man page files that were reported by (Debian) lintian

### DIFF
--- a/cmsfs-fuse/cmsfs-fuse.c
+++ b/cmsfs-fuse/cmsfs-fuse.c
@@ -951,7 +951,7 @@ static void set_record_extension(struct file *f, int *record, off_t addr,
 
 	if (f->record_scan_state != RSS_DATA_BLOCK_STARTED &&
 	    f->record_scan_state != RSS_DATA_BLOCK_EXT)
-		DIE("%s: interal error\n", __func__);
+		DIE("%s: internal error\n", __func__);
 
 	BUG(*record >= f->fst->nr_records);
 

--- a/ipl_tools/cmd_chreipl.c
+++ b/ipl_tools/cmd_chreipl.c
@@ -723,14 +723,14 @@ static void check_exists(const char *path, const char *attr)
 
 	snprintf(fpath, sizeof(fpath), "/sys/firmware/%s", path);
 	if (access(fpath, F_OK) != 0)
-		ERR_EXIT("System does not allow to set %s", attr);
+		ERR_EXIT("System does not allow one to set %s", attr);
 }
 
 static void write_str_optional(char *string, char *file, int exit_on_fail,
 			       const char *attr)
 {
 	if (write_str_errno(string, file) && exit_on_fail)
-		ERR_EXIT("System does not allow to set %s", attr);
+		ERR_EXIT("System does not allow one to set %s", attr);
 }
 
 /*

--- a/tape390/tape390_crypt.c
+++ b/tape390/tape390_crypt.c
@@ -283,7 +283,7 @@ static void tape390_crypt_parse_opts(struct tape390_crypt *info, int argc,
 			    "%s: No device specified.\n",prog_name);
 	if (optind + 1 < argc)
 		ERRMSG_EXIT(EXIT_MISUSE,
-			    "%s: More than one device speficied.\n",prog_name);
+			    "%s: More than one device specified.\n",prog_name);
 	strcpy(info->devname, argv[optind]);
 }
 

--- a/zdev/man/lszdev.8
+++ b/zdev/man/lszdev.8
@@ -86,7 +86,7 @@ By default lszdev displays information from both the active and the persistent
 configuration, and, if available, from the auto-configuration.
 .PP
 .SS Output Format
-In list format, lszdev uses values with the following meaning for the persistent colums (PERS):
+In list format, lszdev uses values with the following meaning for the persistent columns (PERS):
 
 .B yes
 .CL A persistent, non-site specific configuration exists; No site specific configurations available.

--- a/ziomon/ziomon_msg_tools.c
+++ b/ziomon/ziomon_msg_tools.c
@@ -196,7 +196,7 @@ int add_to_agg(struct aggr_data *agg_data, struct message *msg,
 	else if (msg->type == f_hdr->msgid_zfcpdd)
 		aggregate_zfcpdd(agg_data, msg);
 	else {
-		fprintf(stderr, "%s: Unknow msg id: %d,"
+		fprintf(stderr, "%s: Unknown msg id: %d,"
 			" discarding\n", toolname, msg->type);
 		return -1;
 	}

--- a/zkey/ekmfweb/zkey-ekmfweb.c
+++ b/zkey/ekmfweb/zkey-ekmfweb.c
@@ -908,7 +908,7 @@ static const struct util_opt configure_options[] = {
 			"server's certificate. For self signed EKMF Web server "
 			"certificates, this is the default. Use option "
 			"'--tls-pin-server-cert' to ensure the self signed "
-			"certificate's authenticity explicitely. CA signed "
+			"certificate's authenticity explicitly. CA signed "
 			"EKMF Web server certificates are verified by default. "
 			"This option disables the verification.",
 		.command = KMS_COMMAND_CONFIGURE,

--- a/zkey/keystore.c
+++ b/zkey/keystore.c
@@ -1382,7 +1382,7 @@ static int _keystore_lock_repository(struct keystore *keystore)
 		if (fchown(keystore->lock_fd, geteuid(),
 			   keystore->owner) != 0) {
 			rc = -errno;
-			warnx("chown faild on file '%s': %s", lock_file_name,
+			warnx("chown failed on file '%s': %s", lock_file_name,
 			      strerror(-rc));
 			return rc;
 		}

--- a/zpcictl/zpcictl.8
+++ b/zpcictl/zpcictl.8
@@ -90,7 +90,7 @@ a software RAID can transparently re-integrate the recovered device. For
 example, after a failure and recovery, a software RAID can resync a stroage
 device or a network interface can be re-integrated in a bond. In contrast to
 a complete shut down, the device driver remains active and informs higher
-layers of both the occurence of an error state and the eventual recovery.
+layers of both the occurrence of an error state and the eventual recovery.
 .PP
 .
 .OD deconfigure "" "DEVICE"


### PR DESCRIPTION
The changes here fix the following lintian reports:
I: s390-tools: spelling-error-in-binary "allow to" "allow one to" [usr/sbin/chreipl]
I: s390-tools: spelling-error-in-binary Unknow Unknown [usr/sbin/ziomon_mgr]
I: s390-tools: spelling-error-in-binary Unknow Unknown [usr/sbin/ziorep_traffic]
I: s390-tools: spelling-error-in-binary Unknow Unknown [usr/sbin/ziorep_utilization]
I: s390-tools: spelling-error-in-binary interal internal [usr/bin/cmsfs-fuse]
I: s390-tools: spelling-error-in-binary speficied specified [sbin/tape390_crypt]
I: s390-tools-zkey: spelling-error-in-binary explicitely explicitly [usr/libexec/zkey/zkey-ekmfweb.so]
I: s390-tools-zkey: spelling-error-in-binary faild failed [usr/bin/zkey]
I: s390-tools: typo-in-manual-page colums columns [usr/share/man/man8/lszdev.8.gz:89]
I: s390-tools: typo-in-manual-page occurence occurrence [usr/share/man/man8/zpcictl.8.gz:93]
