### PR TITLE
zfcpdump: do not save timestamp when compressing

### DIFF
--- a/zfcpdump/Makefile
+++ b/zfcpdump/Makefile
@@ -35,7 +35,7 @@ zfcpdump_part: zfcpdump.o zfcpdump_part.o
 
 $(ZFCPDUMP_INITRD): cpioinit zfcpdump_part
 	$(CPIOINIT) zfcpdump_part > $@.tmp
-	$(GZIP) -f $@.tmp
+	$(GZIP) -f -n $@.tmp
 	$(MV) $@.tmp.gz $(ZFCPDUMP_INITRD)
 
 scripts: $(INSTALL_SCRIPTS)


### PR DESCRIPTION
Having timestamps in gzip leads to lintian warning 'package-contains-timestamped-gzip' and will harm reproducible builds.
Gzip option '-n' avoids saving original file name and especially timestamp by default.