### PR TITLE
Fix error: heap section not conform to memory layout

### DIFF
--- a/genprotimg/boot/stage3a.lds.S
+++ b/genprotimg/boot/stage3a.lds.S
@@ -93,5 +93,6 @@ SECTIONS
 		*(.eh_frame)
 		*(.interp)
 		*(.note.GNU-stack)
+		*(.note.package)
 	}
 }

--- a/genprotimg/boot/stage3b.lds.S
+++ b/genprotimg/boot/stage3b.lds.S
@@ -79,5 +79,6 @@ SECTIONS
 		*(.eh_frame)
 		*(.interp)
 		*(.note.GNU-stack)
+		*(.note.package)
 	}
 }

--- a/genprotimg/boot/stage3b_reloc.lds.S
+++ b/genprotimg/boot/stage3b_reloc.lds.S
@@ -15,5 +15,6 @@ SECTIONS
 		*(.eh_frame)
 		*(.interp)
 		*(.note.GNU-stack)
+		*(.note.package)
 	}
 }

--- a/zipl/boot/eckd2dump_sv.lds.S
+++ b/zipl/boot/eckd2dump_sv.lds.S
@@ -72,5 +72,6 @@ SECTIONS
     *(.eh_frame)
     *(.interp)
     *(.note.GNU-stack)
+    *(.note.package)
   }
 }

--- a/zipl/boot/stage0.lds.S
+++ b/zipl/boot/stage0.lds.S
@@ -14,5 +14,6 @@ SECTIONS
     *(.eh_frame)
     *(.interp)
     *(.note.GNU-stack)
+    *(.note.package)
   }
 }

--- a/zipl/boot/stage1.lds.S
+++ b/zipl/boot/stage1.lds.S
@@ -14,5 +14,6 @@ SECTIONS
     *(.eh_frame)
     *(.interp)
     *(.note.GNU-stack)
+    *(.note.package)
   }
 }

--- a/zipl/boot/stage1b.lds.S
+++ b/zipl/boot/stage1b.lds.S
@@ -14,5 +14,6 @@ SECTIONS
     *(.eh_frame)
     *(.interp)
     *(.note.GNU-stack)
+    *(.note.package)
  }
 }

--- a/zipl/boot/stage2.lds.S
+++ b/zipl/boot/stage2.lds.S
@@ -93,5 +93,6 @@ SECTIONS
     *(.eh_frame)
     *(.interp)
     *(.note.GNU-stack)
+    *(.note.package)
   }
 }

--- a/zipl/boot/stage3.lds.S
+++ b/zipl/boot/stage3.lds.S
@@ -74,5 +74,6 @@ SECTIONS
     *(.eh_frame)
     *(.interp)
     *(.note.GNU-stack)
+    *(.note.package)
   }
 }


### PR DESCRIPTION
The .note.package [1] section is not used by the zipl/genprotimg bootloaders,
therefore discard them via linker script.
This fix solves the error:
/usr/bin/ld: Heap section doesn't conform to the described memory layout  
collect2: error: ld returned 1 exit status  
make[4]: *** [Makefile:77: stage3a.elf] Error 1
make[4]: Leaving directory '/<>/genprotimg/boot'
make[3]: *** [Makefile:20: all-recursive] Error 1
make[3]: Leaving directory '/<>/genprotimg'
make[2]: *** [Makefile:56: genprotimg] Error 2
[1] https://systemd.io/ELF_PACKAGE_METADATA/

Author: Marc Hartmayer <mhartmay@linux.ibm.com>

Signed-off-by: Frank Heimes <frank.heimes@canonical.com>