### PR TITLE
zipl: Update inline assembly for GCC 15

### DIFF
--- a/zipl/boot/stage3.c
+++ b/zipl/boot/stage3.c
@@ -48,9 +48,9 @@ static inline void __noreturn start_kernel(void)
 		"       diag    %[code],%[code],0x308\n"
 		".no_diag308:\n"
 		"       sam31\n"
-		"       sr      %r1,%r1\n"
-		"       sr      %r2,%r2\n"
-		"       sigp    %r1,%r2,%[order]\n"
+		"       sr      %%r1,%%r1\n"
+		"       sr      %%r2,%%r2\n"
+		"       sigp    %%r1,%%r2,%[order]\n"
 		"       lpsw    0\n"
 		: [addr] "=&d" (addr),
 		  [code] "+&d" (code)


### PR DESCRIPTION
Properly escape % (as %%) for extended assembly in stage3.c in start_kernel().

Fixes: https://github.com/ibm-s390-linux/s390-tools/issues/179