### PR TITLE
pvimg: set '--overwrite' flag when using thru genprotimg symlink

### DIFF
--- a/rust/pvimg/src/cli.rs
+++ b/rust/pvimg/src/cli.rs
@@ -299,7 +299,8 @@ impl GenprotimgCliOptions {
         if version_count == 1 {
             CliOptions::new_version_cmd_opts()
         } else {
-            let genprotimg_opts = Self::parse();
+            let mut genprotimg_opts = Self::parse();
+            genprotimg_opts.args.overwrite = true; // backward compatibility with C- genprotimg
             genprotimg_opts.into()
         }
     }


### PR DESCRIPTION
New `pvimg` tool changed already-in-use behaviour of gone `genprotimg`, so existing code in `ostree`/`coreos-installer` failed during CI. Let's manually set the `overwrite` when tool gets executed via symlink.
Issue: https://github.com/openshift/os/issues/1731