### PR TITLE
man: use CR for constant width font

### DIFF
--- a/cpumf/man/lshwc.8
+++ b/cpumf/man/lshwc.8
@@ -206,7 +206,7 @@ Two read operations are performed and a summary line is printed for each
 read operation.
 .sp 1
 .nf
-.ft CW
+.ft CR
 # lshwc -l2 0-1:BP
 Date,Time,CPU,CPU_CYCLES(0),INSTRUCTIONS(1),L1I_DIR_WRITES(2),L1I_PENALTY_CYCLES(3),L1D_DIR_WRITES(4),
 	L1D_PENALTY_CYCLES(5),PROBLEM_STATE_CPU_CYCLES(32),PROBLEM_STATE_INSTRUCTIONS(33)
@@ -220,7 +220,7 @@ Date,Time,CPU,CPU_CYCLES(0),INSTRUCTIONS(1),L1I_DIR_WRITES(2),L1I_PENALTY_CYCLES
 This example shows the counter values of the problem state counter set per CPU.
 CPU 0 and CPU 1 are selected.
 .nf
-.ft CW
+.ft CR
 .sp 1
 # lshwc -l3 -a 0-1:P
 Date,Time,CPU,PROBLEM_STATE_CPU_CYCLES(32),PROBLEM_STATE_INSTRUCTIONS(33)
@@ -239,7 +239,7 @@ Date,Time,CPU,PROBLEM_STATE_CPU_CYCLES(32),PROBLEM_STATE_INSTRUCTIONS(33)
 This example shows the counter values of the basic counter set
 using delta output format.
 .nf
-.ft CW
+.ft CR
 .sp 1
 # lshwc -d -l 10 -i 5 -s :b
 Date,Time,CPU,B0,B1,B2,B3,B4,B5
@@ -259,7 +259,7 @@ Date,Time,CPU,B0,B1,B2,B3,B4,B5
 This example shows the counter values of the problem state counter set with
 CPU 3 selected.
 .nf
-.ft CW
+.ft CR
 .sp 1
 # lshwc -l2 -a 3:P -H --format json
 {

--- a/cpumf/man/pai.8
+++ b/cpumf/man/pai.8
@@ -241,7 +241,7 @@ The program runs for 10 seconds
 (10 intervals of 1000 milliseconds).
 .sp 1
 .nf
-.ft CW
+.ft CR
 # \*c -c0 10
 .ft R
 .fi
@@ -256,7 +256,7 @@ and a comma-separated list of counter number, colon (:),
 and the counter value n hexadecimal notation.
 .sp 1
 .nf
-.ft CW
+.ft CR
 # \*c -r
 0x62a668f2fa 0 event 4096 sample pid 4956/4956 9:0xa7,73:0x8,74:0x18
 0x6319c75653 0 event 4096 sample pid 4972/4972 32:0x1

--- a/dump2tar/man/dump2tar.1
+++ b/dump2tar/man/dump2tar.1
@@ -22,7 +22,7 @@
 .  ds pfont \\n[.f]
 .  nh
 .  na
-.  ft CW
+.  ft CR
 \\$*
 .  ft \\*[pfont]
 .  ad

--- a/iucvterm/doc/hvc_iucv.9
+++ b/iucvterm/doc/hvc_iucv.9
@@ -66,7 +66,7 @@ terminal application
 To connect to the first z/VM IUCV HVC terminal device on the z/VM guest virtual
 machine "LNX1234", run:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvconn LNX1234 lnxhvc0
@@ -215,7 +215,7 @@ For each HVC terminal device, a \fBgetty\fP program must be started.
 To configure and start \fBgetty\fP on a HVC terminal, open
 .BR /etc/inittab (5),
 and add a new entry similar to this one:
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 
@@ -261,7 +261,7 @@ IUCV HVC terminal:
 .IP "1." 4
 To display the current terminal name, issue the command:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 user@host:~$ echo $TERM
@@ -275,7 +275,7 @@ To connect to a z/VM IUCV HVC terminal, run
 .BR iucvconn (1)
 and log in as usual:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 user@host:~$ iucvconn MYLNX01 lnxhvc0
@@ -289,7 +289,7 @@ user@MYLNX01:~$
 To assign the terminal name from step 1. to the terminal environment variable,
 issue the following command:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 user@MYLNX01:~$ export TERM=xterm
@@ -304,7 +304,7 @@ environment variable.
 .PP
 For getty programs, a sample terminal environment configuration might look like:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 h0:2345:respawn:/sbin/agetty -L 9600 hvc0 linux

--- a/iucvterm/doc/iucvconn.1
+++ b/iucvterm/doc/iucvconn.1
@@ -123,7 +123,7 @@ the characters to the connected terminal.
 To access the "lnxterm" terminal on the Linux instance in
 z/VM guest virtual machine LNXSYS01:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvconn LNXSYS01 lnxterm
@@ -134,7 +134,7 @@ iucvconn LNXSYS01 lnxterm
 To access the first z/VM IUCV HVC terminal on the Linux instance in
 z/VM guest virtual machine LNXSYS02:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvconn LNXSYS02 lnxhvc0
@@ -145,7 +145,7 @@ iucvconn LNXSYS02 lnxhvc0
 To create a transcript of the terminal session to the Linux instance in
 z/VM guest virtual machine LNXSYS99:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvconn -s ~/transcripts/lnxsys99 LNXSYS99 lnxhvc0

--- a/iucvterm/doc/iucvtty.1
+++ b/iucvterm/doc/iucvtty.1
@@ -94,7 +94,7 @@ additional options.
 .SH EXAMPLES
 To allow remote logins using the terminal identifier "lnxterm":
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvtty lnxterm
@@ -104,7 +104,7 @@ iucvtty lnxterm
 
 To only allow users from LNXSYS01 to connect to terminal "lnxterm":
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvtty -a LNXSYS01 lnxterm
@@ -115,7 +115,7 @@ iucvtty -a LNXSYS01 lnxterm
 To only allow users from LNXSYS10 through LNXSYS19 to connect to terminal
 "lnxterm":
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvtty -a "LNXSYS1[0-9]" lnxterm
@@ -125,7 +125,7 @@ iucvtty -a "LNXSYS1[0-9]" lnxterm
 
 To use \fB/sbin/sulogin\fP instead of \fB/bin/login\fP for terminal "suterm":
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 iucvtty suterm -- /sbin/sulogin
@@ -136,7 +136,7 @@ iucvtty suterm -- /sbin/sulogin
 An entry in \fB/etc/inittab\fP to facilitate user logins on terminal "lnxterm"
 with \fB/bin/login\fP could be:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 t1:2345:respawn:/usr/bin/iucvtty lnxterm
@@ -147,7 +147,7 @@ t1:2345:respawn:/usr/bin/iucvtty lnxterm
 An entry in \fB/etc/inittab\fP to facilitate user logins on terminal "suterm"
 with \fB/sbin/sulogin\fP in single user mode could be:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 s1:S:respawn:/usr/bin/iucvtty suterm -- /sbin/sulogin

--- a/iucvterm/doc/ts-shell.1
+++ b/iucvterm/doc/ts-shell.1
@@ -79,7 +79,7 @@ users".
 
 The output for "list" authorization is a list of z/VM guest virtual machines,
 for example:
-.ft CW
+.ft CR
 .in +0.25i
 .nf
 
@@ -94,7 +94,7 @@ guest5
 .ft
 The output for "regex" authorization is a list of one or more
 regular expressions, for example:
-.ft CW
+.ft CR
 .in +0.25i
 .nf
 
@@ -109,7 +109,7 @@ Regular expressions for your authorization:
 If \fBts-shell\fP is configured to connect to particular z/VM guest virtual
 machines only, the output for "regex" authorization is followed by a list of
 the user IDs that match at least one of the regular expressions:
-.ft CW
+.ft CR
 .in +0.25i
 .nf
 
@@ -139,7 +139,7 @@ To change the default terminal identifier, use the \fBterminal\fP command.
 
 In the following example, a user opens a terminal connection to the Linux
 instance in z/VM guest virtual machine LNXSYS01:
-.ft CW
+.ft CR
 .in +0.25i
 .nf
 
@@ -164,7 +164,7 @@ If \fBterminal\fP is called with the \fIidentifier\fP being specified,
 If \fIidentifier\fP is not specified, the current default terminal identifier
 is displayed:
 
-.ft CW
+.ft CR
 .in +0.25i
 .nf
 user@ts-shell> terminal
@@ -212,7 +212,7 @@ guest virtual machines.
 A typical \fBIUCV\fP authorization statement in the z/VM directory entry of the
 terminal server z/VM guest virtual machine might be:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 IUCV ANY
@@ -301,7 +301,7 @@ instance.
 
 For example, to create a list of all z/VM guest virtual machines with names that
 start with "LINUX" and are followed by digits, use:
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 
@@ -373,7 +373,7 @@ group name and prefixed with "@".
 
 Here is an example of a Linux user and group authorization:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 alice  =  list:guest01,guest02
@@ -395,7 +395,7 @@ name on a separate line.
 .PP
 The following example shows the usage of the \fIfile:\fP prefix:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 @testgrp = file:/etc/iucvterm/auth/test-systems.list
@@ -427,7 +427,7 @@ To authorize user bob for all z/VM guest virtual machines with names that
 start with "lnx" and are followed with at least three but not more than five
 alphanumeric characters, use:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 bob = regex:lnx\\w{3,5}
@@ -441,7 +441,7 @@ test or production environment: authorize all users in the "testgrp" group for
 all systems in the test environment; and respectively, authorize all users in
 the "prodgrp" group for all systems in the production environment:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 @testgrp = regex:test\\w+
@@ -461,7 +461,7 @@ of the other type are ignored.
 
 Example:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 @users = list:guest01,guest03,guest05
@@ -484,7 +484,7 @@ To use the \fBts-shell\fP as the login shell for Linux users, follow these steps
 Add the path of the \fBts-shell\fP program to the \fI/etc/shells\fP file that
 contains the list of valid login shells:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 echo $(which ts-shell) >> /etc/shells
@@ -498,7 +498,7 @@ Change the login shell of a particular Linux user using the
 .BR chsh (1)
 program:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 chsh -s $(which ts-shell) alice

--- a/iucvterm/doc/ttyrun.8
+++ b/iucvterm/doc/ttyrun.8
@@ -116,7 +116,7 @@ specifies an exit status in this range.
 .SS inittab
 To start \fB/sbin/agetty\fP on terminal device "hvc1", specify:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 h1:2345:respawn:/sbin/\*s hvc1 /sbin/agetty -L 9600 %t linux
@@ -128,7 +128,7 @@ h1:2345:respawn:/sbin/\*s hvc1 /sbin/agetty -L 9600 %t linux
 To start \fB/sbin/agetty\fP on terminal device "hvc1", add the following
 settings to the job file:
 .PP
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 respawn

--- a/man/af_iucv.7
+++ b/man/af_iucv.7
@@ -89,7 +89,7 @@ Socket communication with applications utilizing CMS AF_IUCV support
 An AF_IUCV socket is represented by the following format:
 .PP
 .RS 8
-.ft CW
+.ft CR
 .nf
 #define AF_IUCV    32
 
@@ -290,7 +290,7 @@ It must not match any z/VM user ID in your environment.
 To set an identifier, issue a command like this:
 .PP
 .RS 8
-.ft CW
+.ft CR
 echo \fIidentifier\fP > /sys/devices/qeth/\fI<bus-ID>\fP/hsuid
 .ft
 .RE
@@ -303,7 +303,7 @@ For example, to use "MYHOST01" to bind AF_IUCV sockets to the
 HiperSockets device with bus-ID 0.0.8000, run:
 .PP
 .RS 8
-.ft CW
+.ft CR
 .nf
 echo "MYHOST01" > /sys/devices/qeth/0.0.8000/hsuid
 .fi
@@ -366,7 +366,7 @@ z/VM guest virtual machine with a maximum of 10\^000 outstanding messages for ea
 incoming connection. Your z/VM guest virtual machine is permitted to connect to
 all other z/VM guest virtual machines. The total number of connections for your
 z/VM guest virtual machine cannot exceed 100.
-.ft CW
+.ft CR
 .in +0.25i
 .nf
 

--- a/opticsmon/opticsmon.8
+++ b/opticsmon/opticsmon.8
@@ -22,7 +22,7 @@
 .  ds pfont \fP
 .  nh
 .  na
-.  ft CW
+.  ft CR
 \\$*
 .  ft \\*[pfont]
 .  ad

--- a/vmur/vmur.8
+++ b/vmur/vmur.8
@@ -456,7 +456,7 @@ Identifies the z/VM spool file to be ordered.
 .IP "1." 3
 Start z/VM console spooling by issuing:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # vmcp sp cons start
@@ -471,7 +471,7 @@ Close the console file and transfer it to the reader queue, find the spool ID
 behind the \f(CWFILE\fP keyword in the corresponding CP message.
 In the example below, the spool ID is 398:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # vmcp sp cons clo \(rs* rdr
@@ -484,7 +484,7 @@ RDR FILE 0398 SENT FROM LINUX025 CON WAS 0398 RECS 1872
 Read and save the spool file on the Linux file system in the
 current working directory:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # vmur re -t 398 linux_cons
@@ -496,7 +496,7 @@ current working directory:
 .IP "1." 3
 Send parmfile to the z/VM punch queue and transfer it to the reader queue:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # vmur pun -r /boot/parmfile
@@ -509,7 +509,7 @@ Reader file with spoolid 0465 created.
 Send the Linux kernel image to the z/VM punch queue and
 transfer it to reader queue:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # vmur pun -r /boot/vmlinuz -N image
@@ -522,7 +522,7 @@ Reader file with spoolid 0466 created.
 Move the Linux kernel image to the first and parmfile to
 the second position in the reader queue:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # vmur or 465
@@ -534,7 +534,7 @@ the second position in the reader queue:
 .IP "4."
 Prepare re-IPL from the z/VM reader and reboot:
 
-.ft CW
+.ft CR
 .in +0.25in
 .nf
 # chreipl ccw 0.0.000c

--- a/zdev/man/chzdev.8
+++ b/zdev/man/chzdev.8
@@ -22,7 +22,7 @@
 .  ds pfont \fP
 .  nh
 .  na
-.  ft CW
+.  ft CR
 \\$*
 .  ft \\*[pfont]
 .  ad

--- a/zdev/man/lszdev.8
+++ b/zdev/man/lszdev.8
@@ -22,7 +22,7 @@
 .  ds pfont \fP
 .  nh
 .  na
-.  ft CW
+.  ft CR
 \\$*
 .  ft \\*[pfont]
 .  ad

--- a/zmemtopo/zmemtopo.8
+++ b/zmemtopo/zmemtopo.8
@@ -88,7 +88,7 @@ Without any options zmemtopo displays the tree view with nesting level 3.
 $ zmemtopo
 
 .nf
-.ft CW
+.ft CR
 LPAR/LEVEL     SIZE
 LPAR003          8G
 └LEVEL4_0        8G
@@ -126,7 +126,7 @@ Display table format, by default nesting level 3 is displayed.
 $ zmemtopo -t
 
 .nf
-.ft CW
+.ft CR
         LEVEL 4   0   0   0   0    1   1   1   1    2   2   2   2    3   3   3   3
         LEVEL 3   0   1   2   3    0   1   2   3    0   1   2   3    0   1   2   3
  NR    LPAR SUM
@@ -150,7 +150,7 @@ Display reverse tree with nesting level 4.
 $ zmemtopo -r -l 4
 
 .nf
-.ft CW
+.ft CR
 LEVEL/LPAR     SIZE
 LEVEL4_0       388G
 │ ├LPAR003       8G
@@ -178,7 +178,7 @@ Display reverse full tree. Entries that have no memory increments are visible.
 $ zmemtopo -rf
 
 .nf
-.ft CW
+.ft CR
 .ft
 LEVEL/LPAR      SIZE
 LEVEL4_0        388G
@@ -240,7 +240,7 @@ Display tree with entries which have no memory increments.
 $ zmemtopo -f
 
 .nf
-.ft CW
+.ft CR
 LPAR/LEVEL     SIZE
 LPAR086          2G
 ├LEVEL4_0         -
@@ -287,7 +287,7 @@ Display json format.
 $ zmemtopo --format=json
 
 .nf
-.ft CW
+.ft CR
 {
   "meta": {
     "api_level": "1",
@@ -349,7 +349,7 @@ Display csv format.
 $ zmemtopo --format=csv
 
 .nf
-.ft CW
+.ft CR
  "report_tod","report_partition_nr","increment_size","partition_nr","partition_name","parent_level","parent_entry_idx","level","entry_idx","increment_count"
 "0x0e082f818b066ce82000","74","1073741824","3","LPAR003","-","-","4","0","8"
 "0x0e082f818b066ce82000","74","1073741824","3","LPAR003","4","0","3","0","2"

--- a/zpwr/man/zpwr.1
+++ b/zpwr/man/zpwr.1
@@ -154,7 +154,7 @@ CPU, storage or I/O resources to partitions.
 .SH "EXAMPLES"
 1. Display power readings in human readable format.
 .nf
-.ft CW
+.ft CR
 # zpwr
 LPAR CPU:                       140.00  W
 LPAR Storage:                     1.72  W
@@ -171,7 +171,7 @@ Update interval: 10.00 s
 2. Perform two power measurements with a delay of 10 seconds and output the
 data in json format.
 .nf
-.ft CW
+.ft CR
 # zpwr --format json --delay 10 --count 2
 {
   "meta": {
@@ -223,7 +223,7 @@ data in json format.
 .sp 1
 3. Display power readings in csv format and in stream mode.
 .nf
-.ft CW
+.ft CR
 # zpwr --format csv --stream
 "iteration","time","time_epoch_sec","time_epoch_nsec","update_interval","cpu","storage","io","total","unassigned_resources","infrastructure"
 "0","2025-01-08 07:17:05+0100","1736317025","592784684","10000000000","143000000","1708200","40000000","15550000000","7659162700","5337186700"


### PR DESCRIPTION
Recently groff/troff started to complain about a missing CW font when previewing some of the man pages, with messages like
````
troff:<standard input>:157: warning: cannot select font 'CW'
````
Seems CR is considered a replacement for CW.

I can reproduce the issue when viewing the affected man pages using `F3` in Midnight Commander in Fedora 42.

https://github.com/Perl/perl5/issues/21239 contains a comprehensive overview of the issue, https://forums.fedoraforum.org/showthread.php?331722-quot-man-quot-emits-troff-errors&p=1878222 has a good information as well