### PR TITLE
 lib(ekmfweb|kmipclient): Use ln without -r

### DIFF
--- a/libekmfweb/Makefile
+++ b/libekmfweb/Makefile
@@ -91,13 +91,13 @@ libekmfweb.so.$(VERSION): ALL_LDFLAGS += -shared -Wl,--version-script=libekmfweb
 	-Wl,-z,defs,-Bsymbolic -Wl,-soname,libekmfweb.so.$(VERM)
 libekmfweb.so.$(VERSION): ekmfweb.o utilities.o cca.o $(libs)
 	$(LINK) $(ALL_LDFLAGS) $^ $(LDLIBS) -o $@
-	ln -srf libekmfweb.so.$(VERSION) libekmfweb.so.$(VERM)
-	ln -srf libekmfweb.so.$(VERSION) libekmfweb.so
+	ln -sf libekmfweb.so.$(VERSION) libekmfweb.so.$(VERM)
+	ln -sf libekmfweb.so.$(VERSION) libekmfweb.so
 
 install-libekmfweb.so.$(VERSION): libekmfweb.so.$(VERSION)
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 755 -T libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERSION)
-	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERM)
-	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so
+	ln -sf libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so.$(VERM)
+	ln -sf libekmfweb.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libekmfweb.so
 	$(INSTALL) -d -m 755 $(DESTDIR)$(USRINCLUDEDIR)/ekmfweb
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 644 $(rootdir)include/ekmfweb/ekmfweb.h $(DESTDIR)$(USRINCLUDEDIR)/ekmfweb
 

--- a/libkmipclient/Makefile
+++ b/libkmipclient/Makefile
@@ -113,13 +113,13 @@ libkmipclient.so.$(VERSION): ALL_LDFLAGS += -shared -Wl,--version-script=libkmip
 libkmipclient.so.$(VERSION): kmip.o request.o response.o attribute.o key.o ttlv.o json.o \
 	xml.o https.o tls.o names.o utils.o
 	$(LINK) $(ALL_LDFLAGS) $^ $(LDLIBS) -o $@
-	ln -srf libkmipclient.so.$(VERSION) libkmipclient.so.$(VERM)
-	ln -srf libkmipclient.so.$(VERSION) libkmipclient.so
+	ln -sf libkmipclient.so.$(VERSION) libkmipclient.so.$(VERM)
+	ln -sf libkmipclient.so.$(VERSION) libkmipclient.so
 
 install-libkmipclient.so.$(VERSION): libkmipclient.so.$(VERSION)
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 755 -T libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERSION)
-	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERM)
-	ln -srf $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so
+	ln -sf libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so.$(VERM)
+	ln -sf libkmipclient.so.$(VERSION) $(DESTDIR)$(SOINSTALLDIR)/libkmipclient.so
 	$(INSTALL) -d -m 755 $(DESTDIR)$(USRINCLUDEDIR)/kmipclient
 	$(INSTALL) -g $(GROUP) -o $(OWNER) -m 644 $(rootdir)include/kmipclient/kmipclient.h $(DESTDIR)$(USRINCLUDEDIR)/kmipclient
 


### PR DESCRIPTION
The option isn't portable (not in POSIX or busybox) and it easily works without