### PR TITLE
tools: Fix compilation with musl and gcc 14

### DIFF
--- a/zconf/css/lscss.c
+++ b/zconf/css/lscss.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <libgen.h>
 
 #include "lib/ccw.h"
 #include "lib/util_base.h"

--- a/zdev/src/ccw.c
+++ b/zdev/src/ccw.c
@@ -8,6 +8,7 @@
  */
 
 #include <inttypes.h>
+#include <libgen.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/zdev/src/ccwgroup.c
+++ b/zdev/src/ccwgroup.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 
 #include "lib/util_base.h"
 #include "lib/util_path.h"

--- a/zdev/src/device.c
+++ b/zdev/src/device.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <libgen.h>
 
 #include "lib/util_path.h"
 

--- a/zdev/src/generic_ccw.c
+++ b/zdev/src/generic_ccw.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <libgen.h>
 
 #include "lib/util_path.h"
 


### PR DESCRIPTION
Hi all,

This MR fixes deploying s390-tools on Musl-based systems, like Alpine. These need an extra include:

```
lscss.c: In function 'is_sch_vfio':
lscss.c:392:20: error: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
  392 |         if (strcmp(basename(driver_path), "vfio_ccw") == 0)

device.c: In function 'device_read_active_attrib':
device.c:426:45: error: implicit declaration of function 'basename'; did you mean 'rename'? [-Wimplicit-function-declaration]
  426 |                         value = misc_strdup(basename(link));
      |                                             ^~~~~~~~
      |                                             rename
```

I'd sent this patch to Alpine ages ago ([see this MR](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/70132)) but I forgot to upstream it.

Let me know what you think.