### PR TITLE
Use EVP_PKEY_id() for OpenSSL 1.1 detection

### DIFF
--- a/libekmfweb/Makefile
+++ b/libekmfweb/Makefile
@@ -43,7 +43,7 @@ detect-openssl-version.dep:
 	echo "  #error openssl version 1.1 is required" >> $(TMPFILE)
 	echo "#endif" >> $(TMPFILE)
 	echo "static void __attribute__((unused)) test(void) {" >> $(TMPFILE)
-	echo "    EVP_PKEY_meth_remove(NULL);" >> $(TMPFILE)
+	echo "    EVP_PKEY_id(NULL);" >> $(TMPFILE)
 	echo "}" >> $(TMPFILE)
 	mv $(TMPFILE) $@
 

--- a/libkmipclient/Makefile
+++ b/libkmipclient/Makefile
@@ -46,7 +46,7 @@ detect-openssl-version.dep:
 	echo "  #error openssl version 1.1 is required" >> $(TMPFILE)
 	echo "#endif" >> $(TMPFILE)
 	echo "static void __attribute__((unused)) test(void) {" >> $(TMPFILE)
-	echo "    EVP_PKEY_meth_remove(NULL);" >> $(TMPFILE)
+	echo "    EVP_PKEY_id(NULL);" >> $(TMPFILE)
 	echo "}" >> $(TMPFILE)
 	mv $(TMPFILE) $@
 

--- a/libseckey/Makefile
+++ b/libseckey/Makefile
@@ -28,7 +28,7 @@ detect-openssl-version.dep:
 	echo "  #error openssl version 1.1 is required" >> $(TMPFILE)
 	echo "#endif" >> $(TMPFILE)
 	echo "static void __attribute__((unused)) test(void) {" >> $(TMPFILE)
-	echo "    EVP_PKEY_meth_remove(NULL);" >> $(TMPFILE)
+	echo "    EVP_PKEY_id(NULL);" >> $(TMPFILE)
 	echo "}" >> $(TMPFILE)
 	mv $(TMPFILE) $@
 


### PR DESCRIPTION
The previous function, EVP_PKEY_meth_remove(), was deprecated in OpenSSL 3.0 and fully removed in OpenSSL 4.0. As a result, it fails detection of OpenSSL 1.1+ if OpenSSL 4 is present.