### PR TITLE
rust: print Info and Warn logs to stdout

### DIFF
--- a/rust/pvimg/src/cmd/create.rs
+++ b/rust/pvimg/src/cmd/create.rs
@@ -6,7 +6,7 @@ use std::fs::OpenOptions;
 use std::io::BufReader;
 
 use anyhow::{Context, Result};
-use log::{debug, warn};
+use log::{debug, info, warn};
 use pv::misc::{open_file, try_parse_u64};
 use pvimg::error::OwnExitCode;
 use pvimg::secured_comp::ComponentTrait;
@@ -199,7 +199,7 @@ pub fn create(opt: &CreateBootImageArgs) -> Result<OwnExitCode> {
     };
     writer.finish(op)?;
 
-    warn!("Successfully generated the Secure Execution image.");
+    info!("Successfully generated the Secure Execution image.");
     Ok(OwnExitCode::Success)
 }
 

--- a/rust/utils/src/log.rs
+++ b/rust/utils/src/log.rs
@@ -27,10 +27,11 @@ impl Log for PvLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            if record.level() > Level::Info {
-                eprintln!("{}: {}", record.level(), record.args());
-            } else {
-                eprintln!("{}", record.args());
+            let lvl = record.level();
+            match lvl {
+                Level::Info => println!("{}", record.args()),
+                Level::Warn => println!("{}: {}", lvl, record.args()),
+                _ => eprintln!("{}: {}", lvl, record.args()),
             }
         }
     }


### PR DESCRIPTION
Current PvLogger implementation prints all logs to stderr.
According to the docs, only logs with higher level should be
printed there.
    
This is a problem when tools like pvimg are called from other
code, which expects informational output on stdout. As a result,
stdout is empty even when the tool succeeds.

With this change we can capture logs just right:
```
core@localhost:~$ journalctl -u coreos-ignition-firstboot-complete.service | cut -d ' ' -f5-
systemd[1]: Starting coreos-ignition-firstboot-complete.service - CoreOS Mark Ignition Boot Complete...
coreos-ignition-firstboot-complete[3253]: WARN: Host-key document verification is disabled. The Secure Execution image may not be protected.
coreos-ignition-firstboot-complete[3253]: Use host-key document at '/etc/se-hostkeys/ibm-z-hostkey-1'
coreos-ignition-firstboot-complete[3253]: Use host-key document at '/etc/se-hostkeys/ibm-z-hostkey-2'
coreos-ignition-firstboot-complete[3253]: Successfully generated the Secure Execution image.

zipl[3370]: Boot loader written to vda (0000) - fd:00
coreos-ignition-firstboot-complete[3370]: Looking for components in '/lib/s390-tools'
coreos-ignition-firstboot-complete[3370]: Secure boot support: no
coreos-ignition-firstboot-complete[3370]: Target device information
coreos-ignition-firstboot-complete[3370]:   Device............................: fd:00
coreos-ignition-firstboot-complete[3370]:   Device name.......................: vda
coreos-ignition-firstboot-complete[3370]:   Device driver name................: virtblk
coreos-ignition-firstboot-complete[3370]:   File system block size............: 1024
coreos-ignition-firstboot-complete[3370]:   Base 1:
coreos-ignition-firstboot-complete[3370]:     Disk............................: fd:00
coreos-ignition-firstboot-complete[3370]:     Partition.......................: fd:01
coreos-ignition-firstboot-complete[3370]:     Type............................: disk partition
coreos-ignition-firstboot-complete[3370]:     Disk layout.....................: SCSI disk layout
coreos-ignition-firstboot-complete[3370]:     Geometry - start................: 2048
coreos-ignition-firstboot-complete[3370]:     Physical block size.............: 512
coreos-ignition-firstboot-complete[3370]:     Disk size in physical blocks....: 409600
coreos-ignition-firstboot-complete[3370]: Building bootmap in '/tmp/coreos-installer-OdVAPC'
coreos-ignition-firstboot-complete[3370]: Adding IPL section
coreos-ignition-firstboot-complete[3370]:   kernel image......: /tmp/coreos-installer-OdVAPC/sdboot
coreos-ignition-firstboot-complete[3370]:   component address:
coreos-ignition-firstboot-complete[3370]:     heap area.......: 0x00002000-0x00005fff
coreos-ignition-firstboot-complete[3370]:     stack area......: 0x0000f000-0x0000ffff
coreos-ignition-firstboot-complete[3370]:     internal loader.: 0x0000a000-0x0000dfff
coreos-ignition-firstboot-complete[3370]:     parameters......: 0x00009000-0x000091ff
coreos-ignition-firstboot-complete[3370]:     kernel image....: 0x00010000-0x050401ff
coreos-ignition-firstboot-complete[3370]:     environment blk.: 0x05041000-0x050413ff
coreos-ignition-firstboot-complete[3370]: zIPL environment block content:
coreos-ignition-firstboot-complete[3370]: Preparing boot device: vda.
coreos-ignition-firstboot-complete[3370]: Installing on base disk: vda.
coreos-ignition-firstboot-complete[3370]: Detected SCSI PCBIOS disk layout.
coreos-ignition-firstboot-complete[3370]: Writing SCSI master boot record.
coreos-ignition-firstboot-complete[3370]: Done.
systemd[1]: Finished coreos-ignition-firstboot-complete.service - CoreOS Mark Ignition Boot Complete.
```